### PR TITLE
Rework for sheet and rule sigils

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ end
 Next add the platforms and compilers to your application config:
 
 ```elixir
-config :live_view_native_stylesheet, :platforms, 
+config :live_view_native_stylesheet, :formats, 
   swiftui: LiveViewNative.SwiftUI.StylesheetCompiler
 ```
 
@@ -38,8 +38,20 @@ config :live_view_native_stylesheet, :platforms,
 defmodule MyCustomerStyleCompiler do
   @behavior LiveViewNative.Stylesheet.Compiler
 
-  def compile(rules) do
+  def compile_sheet(sheet) do
+    # parse class names into {<funcSignature>, <rulesBody>}
+  end
+
+  def compile_rules(rules) do
     # parse rules and produce AST
+  end
+
+  defmacro sigil_SHEET(sheet, _modifier) do
+    LiveViewNative.Stylesheet.Compiler.sheet(sheet, &__MODULE__.compile_sheet/1)
+  end
+
+  defmacro sigil_RULES(rules, _modifier) do
+    LiveViewNative.Stylesheet.Compiler.rules(rules, &__MODULE__.compile_rules/1)
   end
 end
 ```
@@ -51,6 +63,12 @@ New stylesheets can be defined specific to each platform. The
 ```elixir
 defmodule MySheet do
   use LiveViewNative.Stylesheet, :swiftui
+
+  ~SHEET"""
+  "color-" <> color_name do
+    color(to_ime(color_name))
+  end
+  """
 
   def class("color-"<>color_name, _target) do
     "color(.#{color_name})"

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+import_config "#{config_env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :live_view_native_stylesheet, :formats, [
+  mock: MockCompiler
+]

--- a/lib/live_view_native/stylesheet/compiler.ex
+++ b/lib/live_view_native/stylesheet/compiler.ex
@@ -1,0 +1,58 @@
+defmodule LiveViewNative.Stylesheet.Compiler do
+  # @callback compile(rules::binary) :: list
+  # @callback sigil_SHEET(sheet::binary, modifier::atom) :: list()
+  # @callback sigil_RULES(block::binary, modifier::atom) :: list()
+
+  def sheet(blocks, compiler) do
+    blocks =
+      blocks
+      |> eval_quoted()
+      |> compiler.()
+
+    quote bind_quoted: [blocks: Macro.escape(blocks)] do
+      for {arguments, body} <- blocks do
+        def class(unquote_splicing(arguments)) do
+          sigil_RULES(unquote(body), nil)
+        end
+      end
+    end
+  end
+
+  def rules(body, compiler) do
+    body
+    |> eval_quoted()
+    |> compiler.()
+    |> Enum.map(&escape(&1))
+  end
+
+  defp eval_quoted(expr) when is_binary(expr), do: expr
+  defp eval_quoted({:<<>>, _, [expr]}), do: expr
+
+  defp escape({operator, meta, arguments}) when operator in [:<>] do
+    {operator, meta, Enum.map(arguments, &escape(&1))}
+  end
+  defp escape({_varname, _meta, Elixir} = expr), do: expr
+  defp escape({identity, annotations, arguments}) do
+    {:{}, [], [identity, annotations, Enum.map(arguments, &escape(&1))]}
+  end
+  defp escape(literal), do: literal
+
+  def compile_rules(format, rules) do
+    compiler = fetch(format)
+    compiler.compile_rules(rules)
+  end
+
+  def compile_sheet(format, class_names) do
+    compiler = fetch(format)
+    compiler.compile_sheet(class_names)
+  end
+
+  def fetch(format) do
+    with {:ok, formats} <- Application.fetch_env(:live_view_native_stylesheet, :formats),
+    {:ok, compiler} <- Keyword.fetch(formats, format) do
+      compiler
+    else
+      :error -> "No compiler found for `#{inspect(format)}`"
+    end
+  end
+end

--- a/lib/live_view_native_stylesheet.ex
+++ b/lib/live_view_native_stylesheet.ex
@@ -1,27 +1,18 @@
 defmodule LiveViewNative.Stylesheet do
-  defmodule Compiler do
-    @callback compile(rules::binary) :: list
-  end
 
-  def compile(platform, rules) do
-    with {:ok, platforms} <- Application.fetch_env(:live_view_native_stylesheet, :platforms),
-    {:ok, compiler} <- Keyword.fetch(platforms, platform) do
-      compiler.compile(rules)
+  defmacro __using__(format) do
+    compiler = LiveViewNative.Stylesheet.Compiler.fetch(format)
 
-    else
-      :error -> "Make sure the compiler for platform `#{inspect(platform)}` is defined in your config for `:live_view_native_stylesheet`"
-    end
-  end
-
-  defmacro __using__(platform) do
     quote do
+      require unquote(compiler)
+      import unquote(compiler), only: [sigil_SHEET: 2, sigil_RULES: 2]
+      @sheet_format unquote(format)
+
       def compile(class_list, target: target) do
         Enum.reduce(class_list, %{}, fn(class_name, class_map) ->
           case class(class_name, target: target) do
-            {:unmatched, msg} ->
-              IO.puts(msg)
-              class_map
-            rules -> Map.put(class_map, class_name, LiveViewNative.Stylesheet.compile(unquote(platform), rules))
+            {:unmatched, msg} -> class_map
+            rules -> Map.put(class_map, class_name, rules)
           end
         end)
       end

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule LiveViewNativeStylesheet.MixProject do
+defmodule LiveViewNative.Stylesheet.MixProject do
   use Mix.Project
 
   def project do
@@ -6,6 +6,7 @@ defmodule LiveViewNativeStylesheet.MixProject do
       app: :live_view_native_stylesheet,
       version: "0.1.0",
       elixir: "~> 1.15",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -17,6 +18,9 @@ defmodule LiveViewNativeStylesheet.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/mocks"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/mocks/mock_compiler.ex
+++ b/test/mocks/mock_compiler.ex
@@ -1,0 +1,46 @@
+defmodule MockCompiler do
+  # @behaviour LiveViewNative.Stylesheet.Compiler
+
+  def compile_sheet(_sheet) do
+    [
+      {["color-yellow", {:_target, [], Elixir}], "rule-21"},
+      {
+        [{:<>, [context: LiveViewNative.Stylesheet.Compiler, imports: [{2, Kernel}]], ["color-hex-", {:number, [], Elixir}]}, {:_target, [], LiveViewNative.Stylesheet.Compiler}],
+         "rule-31\nrule-22"
+      }
+    ]
+  end
+
+  def compile_rules(rules) do
+    rules
+    |> String.split("\n", trim: true)
+    |> Enum.map(&compile_rule(&1))
+  end
+
+  defp compile_rule("rule-31") do
+    {:<>, [], ["rule-31-", {:number, [], Elixir}]}
+  end
+
+  defp compile_rule("rule-21") do
+    {:foobar, [], [1, 2, 3]}
+  end
+
+  defp compile_rule("rule-22") do
+    {:foobar, [], [1, 2, {:number, [], Elixir}]}
+  end
+
+  defp compile_rule("rule-" <> number) do
+    {int, _} = Integer.parse(number)
+    int
+  end
+
+  defp compile_rule(rule), do: rule
+
+  defmacro sigil_SHEET(sheet, _modifier) do
+    LiveViewNative.Stylesheet.Compiler.sheet(sheet, &__MODULE__.compile_sheet/1)
+  end
+
+  defmacro sigil_RULES(rules, _modifier) do
+    LiveViewNative.Stylesheet.Compiler.rules(rules, &__MODULE__.compile_rules/1)
+  end
+end

--- a/test/mocks/mock_sheet.ex
+++ b/test/mocks/mock_sheet.ex
@@ -1,0 +1,39 @@
+defmodule MockSheet do
+  use LiveViewNative.Stylesheet, :mock
+
+  ~SHEET"""
+  "color-hex-" <> number do
+    rule-31-#{number}
+    rule-22(number)
+  end
+
+  "color-yellow" do
+    rule-21
+  end
+  """
+
+  def class("color-red", _target) do
+    ~RULES"""
+    rule-1
+    rule-3
+    rule-4
+    """
+  end
+
+  def class("color-blue", target: :watch) do
+    ~RULES"""
+    rule-4
+    rule-5
+    """
+  end
+
+  def class("color-blue", _target) do
+    ~RULES"""
+    rule-2
+    """
+  end
+
+  def class(unmatched, target: target) do
+    {:unmatched, "Stylesheet warning: Could not match on class: #{inspect(unmatched)} for target: #{inspect(target)}"}
+  end
+end


### PR DESCRIPTION
We can now build stylesheets with `~SHEET` sigils and declare rules within functions with `~RULES` sigils. Customer compilers need to support the function parsing