### PR TITLE
Improve sheet setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ config :live_view_native_stylesheet, :parsers,
 defmodule MyCustomerRulesParser do
   use LiveViewNative.Stylesheet.RulesParser, :swiftui
 
+  defmacro __using__(_) do
+    quote do
+      import MyCustomRulesParser, only: [sigil_RULES: 2]
+      import MyCustomRulesHelpers
+    end
+  end
+
   def parse(rules) do
     # your custom parser defined here
   end
@@ -47,6 +54,15 @@ end
 The `format` passed in during the `use` will define a new `sigil_RULES/2` function within
 your customer parser. The `format` is carried through this function so make sure it matches
 the `format` used for the sheet itself.
+
+You *must* implement the `__using__/1` macro and at least `import` `sigil_RULES/2` from your
+custom parser. `sigil_RULES/2` is injected into your module from `LiveViewNative.Stylesheet.RulesParser`.
+This is also a good place to include other `import`s that are necessary to support the compilation of
+the final stylsheet. In the example above `import MyCustomRulesHelpers` may include additional helpers
+available to your parser's rule set.
+
+You *must* implement the `parse/1` function as this is your primary hook for parsing the rules
+found within the body of each class from the sheet
 
 ## Writing stylesheets
 

--- a/lib/live_view_native/stylesheet/rules_parser.ex
+++ b/lib/live_view_native/stylesheet/rules_parser.ex
@@ -1,5 +1,6 @@
 defmodule LiveViewNative.Stylesheet.RulesParser do
   @callback parse(rules::binary) :: list
+  @macrocallback __using__([]) :: list
 
   defmacro __using__(format) do
     quote do

--- a/lib/live_view_native_stylesheet.ex
+++ b/lib/live_view_native_stylesheet.ex
@@ -4,8 +4,9 @@ defmodule LiveViewNative.Stylesheet do
       {:ok, parser} ->
         quote do
           import LiveViewNative.Stylesheet.SheetParser, only: [sigil_SHEET: 2]
-          import unquote(parser), only: [sigil_RULES: 2]
           import LiveViewNative.Stylesheet.RulesHelpers
+
+          use unquote(parser)
 
           @sheet_format unquote(format)
 

--- a/test/mocks/mock_rules_parser.ex
+++ b/test/mocks/mock_rules_parser.ex
@@ -1,6 +1,11 @@
 defmodule MockRulesParser do
-  # @behaviour LiveViewNative.Stylesheet.parser
   use LiveViewNative.Stylesheet.RulesParser, :mock
+
+  defmacro __using__(_) do
+    quote do
+      import MockRulesParser, only: [sigil_RULES: 2]
+    end
+  end
 
   def parse(rules) do
     rules


### PR DESCRIPTION
Using `use` for the custom rules parser allows the parsers to individually declare additional imports available to the runtime of sheet compilation