### PR TITLE
Various fixes

### DIFF
--- a/lib/live_view_native/stylesheet/rules_parser/helpers.ex
+++ b/lib/live_view_native/stylesheet/rules_parser/helpers.ex
@@ -12,17 +12,17 @@ defmodule LiveViewNative.Stylesheet.RulesParser.Helpers do
     "underscore"
   ]
 
-  def parse(opts \\ []) do
-    additional_functions = Keyword.get(opts, :additional, [])
-
-    choice(Enum.map(@helper_functions ++ additional_functions, &string(&1)))
+  defp create_combinator(function_names) do
+    choice(Enum.map(function_names, &string(&1)))
     |> enclosed("(", variable(), ")")
     |> post_traverse({:to_function_call_ast, []})
     |> post_traverse({:tag_as_elixir_code, []})
   end
 
   defmacro __using__(opts \\ []) do
-    module_name = __MODULE__
+    additional_functions = Keyword.get(opts, :additional, [])
+
+    combinator = create_combinator(@helper_functions ++ additional_functions)
 
     quote do
       import NimbleParsec
@@ -30,9 +30,7 @@ defmodule LiveViewNative.Stylesheet.RulesParser.Helpers do
       import LiveViewNative.Stylesheet.SheetParser.PostProcessors,
         only: [to_function_call_ast: 5, to_elixir_variable_ast: 5, tag_as_elixir_code: 5]
 
-      defparsec(:helper_function, unquote(module_name).parse(unquote(opts)),
-        export_combinator: true
-      )
+      defparsec(:helper_function, unquote(Macro.escape(combinator)), export_combinator: true)
     end
   end
 end

--- a/lib/live_view_native/stylesheet/rules_parser/helpers.ex
+++ b/lib/live_view_native/stylesheet/rules_parser/helpers.ex
@@ -2,6 +2,7 @@ defmodule LiveViewNative.Stylesheet.RulesParser.Helpers do
   @moduledoc false
   import NimbleParsec
   import LiveViewNative.Stylesheet.SheetParser.Tokens, only: [variable: 0, enclosed: 4]
+  alias LiveViewNative.Stylesheet.SheetParser.PostProcessors
 
   @helper_functions [
     "to_atom",
@@ -15,8 +16,8 @@ defmodule LiveViewNative.Stylesheet.RulesParser.Helpers do
   defp create_combinator(function_names) do
     choice(Enum.map(function_names, &string(&1)))
     |> enclosed("(", variable(), ")")
-    |> post_traverse({:to_function_call_ast, []})
-    |> post_traverse({:tag_as_elixir_code, []})
+    |> post_traverse({PostProcessors, :to_function_call_ast, []})
+    |> post_traverse({PostProcessors, :tag_as_elixir_code, []})
   end
 
   defmacro __using__(opts \\ []) do

--- a/lib/live_view_native/stylesheet/sheet_parser/block.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/block.ex
@@ -2,7 +2,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Block do
   @moduledoc false
   import NimbleParsec
   import LiveViewNative.Stylesheet.SheetParser.Tokens
-  import LiveViewNative.Stylesheet.SheetParser.PostProcessors
+  alias LiveViewNative.Stylesheet.SheetParser.PostProcessors
 
   string_with_variable =
     double_quoted_string()
@@ -10,7 +10,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Block do
     |> ignore(string("<>"))
     |> ignore_whitespace()
     |> concat(variable())
-    |> post_traverse({:block_open_with_variable_to_ast, []})
+    |> post_traverse({PostProcessors, :block_open_with_variable_to_ast, []})
 
   key_value_pairs =
     ignore_whitespace()
@@ -35,7 +35,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Block do
       )
     )
     |> ignore(string(" do"))
-    |> post_traverse({:block_open_to_ast, []})
+    |> post_traverse({PostProcessors, :block_open_to_ast, []})
 
   block_close =
     ignore_whitespace()
@@ -61,7 +61,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Block do
       |> concat(block_open)
       |> concat(block_contents_as_string)
       |> concat(block_close)
-      |> post_traverse({:wrap_in_tuple, []})
+      |> post_traverse({PostProcessors, :wrap_in_tuple, []})
     )
     |> ignore_whitespace()
     |> eos(),

--- a/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
@@ -33,6 +33,6 @@ defmodule LiveViewNative.Stylesheet.SheetParser.PostProcessors do
   def to_function_call_ast(rest, args, context, _line, _offset) do
     [ast_name | other_args] = Enum.reverse(args)
 
-    {rest, [{String.to_atom(ast_name), [], other_args}], context}
+    {rest, [{Elixir, [], {String.to_atom(ast_name), [], other_args}}], context}
   end
 end

--- a/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
@@ -33,6 +33,6 @@ defmodule LiveViewNative.Stylesheet.SheetParser.PostProcessors do
   def to_function_call_ast(rest, args, context, _line, _offset) do
     [ast_name | other_args] = Enum.reverse(args)
 
-    {rest, [{Elixir, [], {String.to_atom(ast_name), [], other_args}}], context}
+    {rest, [{String.to_atom(ast_name), [], other_args}], context}
   end
 end

--- a/lib/live_view_native/stylesheet/sheet_parser/tokens.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/tokens.ex
@@ -1,5 +1,6 @@
 defmodule LiveViewNative.Stylesheet.SheetParser.Tokens do
   import NimbleParsec
+  alias LiveViewNative.Stylesheet.SheetParser.PostProcessors
 
   #
   # Literals
@@ -94,7 +95,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Tokens do
     ascii_string([?a..?z, ?A..?Z, ?_], 1)
     |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_], min: 1)
     |> reduce({Enum, :join, [""]})
-    |> post_traverse({:to_elixir_variable_ast, []})
+    |> post_traverse({PostProcessors, :to_elixir_variable_ast, []})
   end
 
   def word() do
@@ -141,7 +142,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Tokens do
     |> concat(ignore(string(":")))
     |> ignore(whitespace(min: 1))
     |> concat(literal())
-    |> post_traverse({:to_keyword_tuple_ast, []})
+    |> post_traverse({PostProcessors, :to_keyword_tuple_ast, []})
   end
 
   def enclosed(start \\ empty(), open, combinator, close) do

--- a/test/mocks/mock_rules_helpers.ex
+++ b/test/mocks/mock_rules_helpers.ex
@@ -1,8 +1,8 @@
 defmodule MockRulesHelpers do
   # Implements a parse/1 function that can be used to parse helper functions
-  use LiveViewNative.Stylesheet.RulesParser.Helpers, additional: ["to_ime"]
+  use LiveViewNative.Stylesheet.RulesParser.Helpers, additional: ["to_abc"]
 
-  def to_ime(expr) when is_binary(expr) do
+  def to_abc(expr) when is_binary(expr) do
     # ...
   end
 end

--- a/test/rules_parser_test.exs
+++ b/test/rules_parser_test.exs
@@ -55,16 +55,16 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
     test "can parse standard helpers" do
       input = "to_float(number)"
 
-      output = {Elixir, [], {Elixir, [], {:to_float, [], [{:number, [], Elixir}]}}}
+      output = {Elixir, [], {:to_float, [], [{:number, [], Elixir}]}}
 
       assert {:ok, [result], _, _, _, _} = MockRulesHelpers.helper_function(input)
       assert result == output
     end
 
     test "can parse additional helpers" do
-      input = "to_ime(family)"
+      input = "to_abc(family)"
 
-      output = {Elixir, [], {Elixir, [], {:to_ime, [], [{:family, [], Elixir}]}}}
+      output = {Elixir, [], {:to_abc, [], [{:family, [], Elixir}]}}
 
       assert {:ok, [result], _, _, _, _} = MockRulesHelpers.helper_function(input)
       assert result == output

--- a/test/rules_parser_test.exs
+++ b/test/rules_parser_test.exs
@@ -55,7 +55,7 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
     test "can parse standard helpers" do
       input = "to_float(number)"
 
-      output = {Elixir, [], {:to_float, [], [{:number, [], Elixir}]}}
+      output = {Elixir, [], {Elixir, [], {:to_float, [], [{:number, [], Elixir}]}}}
 
       assert {:ok, [result], _, _, _, _} = MockRulesHelpers.helper_function(input)
       assert result == output
@@ -64,7 +64,7 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
     test "can parse additional helpers" do
       input = "to_ime(family)"
 
-      output = {Elixir, [], {:to_ime, [], [{:family, [], Elixir}]}}
+      output = {Elixir, [], {Elixir, [], {:to_ime, [], [{:family, [], Elixir}]}}}
 
       assert {:ok, [result], _, _, _, _} = MockRulesHelpers.helper_function(input)
       assert result == output


### PR DESCRIPTION
- Remove `parse` function from `RulesParser.Helpers`
- Emit correct function call AST