### PR TITLE
Various fixes to support more flexible sheet generation

### DIFF
--- a/lib/live_view_native_stylesheet.ex
+++ b/lib/live_view_native_stylesheet.ex
@@ -10,11 +10,14 @@ defmodule LiveViewNative.Stylesheet do
 
           @sheet_format unquote(format)
 
+          def compile(class_or_list, target \\ [target: :all])
           def compile(class_list, target: target) do
-            Enum.reduce(class_list, %{}, fn(class_name, class_map) ->
+            class_list
+            |> List.wrap()
+            |> Enum.reduce(%{}, fn(class_name, class_map) ->
               case class(class_name, target: target) do
                 {:unmatched, msg} -> class_map
-                rules -> Map.put(class_map, class_name, rules)
+                rules -> Map.put(class_map, class_name, List.wrap(rules))
               end
             end)
           end

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -20,6 +20,24 @@ defmodule LiveViewNative.StylesheetTest do
     assert output == %{}
   end
 
+  test "can compile without target, will default to `target: :all`" do
+    output = MockSheet.compile(["color-blue", "color-red"])
+
+    assert output == %{"color-blue" => [2], "color-red" => [1,3,4]}
+  end
+
+  test "can compile for a single class name" do
+    output = MockSheet.compile("color-blue")
+
+    assert output == %{"color-blue" => [2]}
+  end
+
+  test "can compile when a rule set is not a list" do
+    output = MockSheet.compile("single")
+
+    assert output == %{"single" => [{:single, [], [1]}]}
+  end
+
   describe "LiveViewNative.Stylesheet sigil" do
     test "single rules supported" do
       output = MockSheet.compile(["color-yellow"], target: :all)

--- a/test/mocks/mock_sheet.ex
+++ b/test/mocks/mock_sheet.ex
@@ -33,6 +33,10 @@ defmodule MockSheet do
     """
   end
 
+  def class("single", _target) do
+    {:single, [], [1]}
+  end
+
   def class(unmatched, target: target) do
     {:unmatched, "Stylesheet warning: Could not match on class: #{inspect(unmatched)} for target: #{inspect(target)}"}
   end


### PR DESCRIPTION
* allow for multiple ways to call `Sheet.compile`
* ensures that rules from a class are always lists