### PR TITLE
Add annotations to Sheet and Helper parser; Add errors to Sheet parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Next add the platforms and compilers to your application config:
 ```elixir
 config :live_view_native_stylesheet, :parsers, 
   swiftui: LiveViewNative.SwiftUI.RulesParser
+
+# For production environments, you can opt out of annotations
+# for smaller outputs
+config :live_view_native_stylesheet,
+  annotations: false
 ```
 
 ## Building a stylesheet rules parser

--- a/lib/live_view_native/stylesheet/rules_parser.ex
+++ b/lib/live_view_native/stylesheet/rules_parser.ex
@@ -30,14 +30,18 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
         |> parser.parse()
         |> List.wrap()
         |> Enum.map(&escape(&1))
-      {:error, message} -> raise message
+
+      {:error, message} ->
+        raise message
     end
   end
 
   defp escape({operator, meta, arguments}) when operator in [:<>] do
     {operator, meta, Enum.map(arguments, &escape(&1))}
   end
+
   defp escape({Elixir, _meta, expr}), do: expr
+
   defp escape({identity, annotations, arguments}) do
     {:{}, [], [identity, annotations, escape(arguments)]}
   end
@@ -47,5 +51,6 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
   defp escape([argument | tail]) do
     [escape(argument) | escape(tail)]
   end
+
   defp escape(literal), do: literal
 end

--- a/lib/live_view_native/stylesheet/rules_parser.ex
+++ b/lib/live_view_native/stylesheet/rules_parser.ex
@@ -30,18 +30,14 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
         |> parser.parse()
         |> List.wrap()
         |> Enum.map(&escape(&1))
-
-      {:error, message} ->
-        raise message
+      {:error, message} -> raise message
     end
   end
 
   defp escape({operator, meta, arguments}) when operator in [:<>] do
     {operator, meta, Enum.map(arguments, &escape(&1))}
   end
-
   defp escape({Elixir, _meta, expr}), do: expr
-
   defp escape({identity, annotations, arguments}) do
     {:{}, [], [identity, annotations, escape(arguments)]}
   end
@@ -51,6 +47,5 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
   defp escape([argument | tail]) do
     [escape(argument) | escape(tail)]
   end
-
   defp escape(literal), do: literal
 end

--- a/lib/live_view_native/stylesheet/rules_parser/helpers.ex
+++ b/lib/live_view_native/stylesheet/rules_parser/helpers.ex
@@ -1,8 +1,10 @@
 defmodule LiveViewNative.Stylesheet.RulesParser.Helpers do
   @moduledoc false
   import NimbleParsec
-  import LiveViewNative.Stylesheet.SheetParser.Tokens, only: [variable: 0, enclosed: 4]
+  import LiveViewNative.Stylesheet.SheetParser.Tokens, only: [variable: 0]
+  import LiveViewNative.Stylesheet.SheetParser.Expressions, only: [enclosed: 5]
   alias LiveViewNative.Stylesheet.SheetParser.PostProcessors
+  alias LiveViewNative.Stylesheet.SheetParser.Parser
 
   @helper_functions [
     "to_atom",
@@ -14,10 +16,16 @@ defmodule LiveViewNative.Stylesheet.RulesParser.Helpers do
   ]
 
   defp create_combinator(function_names) do
-    choice(Enum.map(function_names, &string(&1)))
-    |> enclosed("(", variable(), ")")
+    Parser.start()
+    |> pre_traverse({PostProcessors, :mark_line, [:open_function_line]})
+    |> pre_traverse({PostProcessors, :mark_line, [:open_elixir_code]})
+    |> choice(Enum.map(function_names, &string(&1)))
+    |> enclosed("(", variable(), ")", [])
     |> post_traverse({PostProcessors, :to_function_call_ast, []})
     |> post_traverse({PostProcessors, :tag_as_elixir_code, []})
+    |> post_traverse({PostProcessors, :unmark_line, [:open_function_line]})
+    |> post_traverse({PostProcessors, :unmark_line, [:open_elixir_code]})
+    |> label("a 1-arity helper function (#{Enum.join(function_names, ", ")})")
   end
 
   defmacro __using__(opts \\ []) do

--- a/lib/live_view_native/stylesheet/sheet_parser.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser.ex
@@ -12,7 +12,8 @@ defmodule LiveViewNative.Stylesheet.SheetParser do
       context: %{
         file: file,
         source_line: line,
-        module: module
+        module: module,
+        annotations: Application.get_env(:live_view_native_stylesheet, :annotations, true)
       }
     ]
 

--- a/lib/live_view_native/stylesheet/sheet_parser/expressions.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/expressions.ex
@@ -1,0 +1,85 @@
+defmodule LiveViewNative.Stylesheet.SheetParser.Expressions do
+  import NimbleParsec
+  import LiveViewNative.Stylesheet.SheetParser.Parser
+  import LiveViewNative.Stylesheet.SheetParser.Tokens
+  alias LiveViewNative.Stylesheet.SheetParser.PostProcessors
+
+  def enclosed(start, open, combinator, close, opts) do
+    allow_empty? = Keyword.get(opts, :allow_empty?, true)
+
+    close =
+      expected(
+        ignore(string(close)),
+        error_message: "expected ‘#{close}’",
+        error_parser: optional(non_whitespace())
+      )
+
+    start
+    |> ignore(string(open))
+    |> ignore_whitespace()
+    |> concat(
+      if allow_empty? do
+        optional2(combinator)
+      else
+        combinator
+      end
+    )
+    |> ignore_whitespace()
+    |> concat(close)
+  end
+
+  #
+  # Collections
+  #
+
+  def comma_separated_list(start \\ empty(), elem_combinator, opts \\ []) do
+    delimiter_separated_list(
+      start,
+      elem_combinator,
+      ",",
+      Keyword.merge([allow_empty?: true], opts)
+    )
+  end
+
+  defp delimiter_separated_list(combinator, elem_combinator, delimiter, opts) do
+    allow_empty? = Keyword.get(opts, :allow_empty?, true)
+
+    #  1+ elems
+    non_empty =
+      elem_combinator
+      |> repeat(
+        ignore_whitespace()
+        |> ignore(string(delimiter))
+        |> ignore_whitespace()
+        |> concat(elem_combinator)
+      )
+
+    if allow_empty? do
+      combinator
+      |> optional2(non_empty)
+    else
+      combinator
+      |> concat(non_empty)
+    end
+
+    # end
+  end
+
+  def key_value_pair() do
+    ignore_whitespace()
+    |> concat(word())
+    |> concat(ignore(string(":")))
+    |> ignore(whitespace(min: 1))
+    |> concat(literal(error_parser: empty()))
+    |> post_traverse({PostProcessors, :to_keyword_tuple_ast, []})
+  end
+
+  def key_value_pairs(opts \\ []) do
+    comma_separated_list(
+      empty(),
+      key_value_pair(),
+      opts
+    )
+    |> wrap()
+  end
+end

--- a/lib/live_view_native/stylesheet/sheet_parser/parser.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser.ex
@@ -1,6 +1,5 @@
 defmodule LiveViewNative.Stylesheet.SheetParser.Parser do
   import NimbleParsec
-  alias __MODULE__
   alias LiveViewNative.Stylesheet.SheetParser.Parser.Context
   alias LiveViewNative.Stylesheet.SheetParser.Parser.Error
 
@@ -79,7 +78,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser do
   end
 
   def put_error(error_parser, error_message, opts \\ []) do
-    post_traverse(error_parser, {Parser.Error, :put_error, [error_message, opts]})
+    post_traverse(error_parser, {Error, :put_error, [error_message, opts]})
   end
 
   @whitespace_chars [?\s, ?\t, ?\n, ?\r]
@@ -111,7 +110,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser do
   end
 
   def repeat_until(combinator, matches) do
-    repeat_while(combinator, {Parser, :not_match, [matches]})
+    repeat_while(combinator, {__MODULE__, :not_match, [matches]})
   end
 
   def not_match(<<char::utf8, _::binary>>, context, _, _, matches) do

--- a/lib/live_view_native/stylesheet/sheet_parser/parser.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser.ex
@@ -1,0 +1,140 @@
+defmodule LiveViewNative.Stylesheet.SheetParser.Parser do
+  import NimbleParsec
+  alias __MODULE__
+  alias LiveViewNative.Stylesheet.SheetParser.Parser.Context
+  alias LiveViewNative.Stylesheet.SheetParser.Parser.Error
+
+  def start() do
+    pre_traverse(empty(), {Context, :prepare_context, []})
+  end
+
+  def label_from_named_choices(named_choices) do
+    {_, names} = Enum.unzip(named_choices)
+
+    names
+    |> Enum.map(&(" - " <> &1))
+    |> Enum.join("\n")
+  end
+
+  def one_of(combinator \\ empty(), named_choices, opts \\ []) do
+    if not match?([_, _ | _], named_choices) do
+      raise ArgumentError, "one_of expects two or more choices"
+    end
+
+    error_parser = Keyword.get(opts, :error_parser, non_whitespace())
+    show_incorrect_text? = Keyword.get(opts, :show_incorrect_text?, false)
+    generate_error? = Keyword.get(opts, :generate_error?, true)
+
+    {choices, _} = Enum.unzip(named_choices)
+
+    #
+    choice(
+      combinator,
+      choices ++
+        if generate_error? do
+          [
+            error_parser
+            |> put_error(
+              "Expected one of the following:\n" <>
+                label_from_named_choices(named_choices) <> "\n",
+              show_incorrect_text?: show_incorrect_text?
+            )
+          ]
+        else
+          []
+        end
+    )
+  end
+
+  def expected(combinator \\ empty(), combinator_2, opts) do
+    error_parser = Keyword.get(opts, :error_parser, non_whitespace())
+    error_message = Keyword.get(opts, :error_message)
+    generate_error? = Keyword.get(opts, :generate_error?, true)
+
+    combinator
+    |> concat(
+      if generate_error? do
+        choice([
+          combinator_2,
+          put_error(error_parser, error_message, opts)
+        ])
+      else
+        combinator_2
+      end
+    )
+  end
+
+  def optional2(combinator \\ empty(), combinator_2) do
+    combinator
+    |> post_traverse({Context, :freeze_context, []})
+    |> optional(combinator_2)
+    |> post_traverse({Context, :unfreeze_context, []})
+  end
+
+  def frozen(combinator \\ empty(), combinator_2) do
+    combinator
+    |> concat(combinator_2)
+    |> pre_traverse({Context, :freeze_context, []})
+    |> post_traverse({Context, :unfreeze_context, []})
+  end
+
+  def put_error(error_parser, error_message, opts \\ []) do
+    error_parser
+    |> post_traverse({Parser.Error, :put_error, [error_message, opts]})
+  end
+
+  @whitespace_chars [?\s, ?\t, ?\n, ?\r]
+
+  def non_whitespace(opts \\ []) do
+    also_ignore = Keyword.get(opts, :also_ignore, [])
+    fail_if_empty = Keyword.get(opts, :fail_if_empty, false)
+
+    repeat_until(utf8_char([]), @whitespace_chars ++ also_ignore)
+    |> reduce({List, :to_string, []})
+    |> post_traverse({__MODULE__, :delete_if_empty_string, []})
+    |> post_traverse({__MODULE__, :fail_if_empty, [fail_if_empty]})
+  end
+
+  def delete_if_empty_string(rest, [""], context, _, _) do
+    {rest, [], context}
+  end
+
+  def delete_if_empty_string(rest, args, context, _, _) do
+    {rest, args, context}
+  end
+
+  def fail_if_empty(_, [], _, _, _, true) do
+    {:error, "non_whitespace is empty"}
+  end
+
+  def fail_if_empty(rest, args, context, _, _, _) do
+    {rest, args, context}
+  end
+
+  def repeat_until(combinator, matches) do
+    repeat_while(combinator, {Parser, :not_match, [matches]})
+  end
+
+  def not_match(<<char::utf8, _::binary>>, context, _, _, matches) do
+    if char in matches do
+      {:halt, context}
+    else
+      {:cont, context}
+    end
+  end
+
+  def not_match("", context, _, _, _) do
+    {:cont, context}
+  end
+
+  def error_from_result(result) do
+    case result do
+      {_, _output, rest, %{context: %Context{errors: [_ | _]} = context}, _position, _byte_offset} ->
+        {message, position, byte_offset} = Error.context_to_error_message(context)
+        {:error, message, rest, context, position, byte_offset}
+
+      result ->
+        result
+    end
+  end
+end

--- a/lib/live_view_native/stylesheet/sheet_parser/parser.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser.ex
@@ -79,8 +79,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser do
   end
 
   def put_error(error_parser, error_message, opts \\ []) do
-    error_parser
-    |> post_traverse({Parser.Error, :put_error, [error_message, opts]})
+    post_traverse(error_parser, {Parser.Error, :put_error, [error_message, opts]})
   end
 
   @whitespace_chars [?\s, ?\t, ?\n, ?\r]

--- a/lib/live_view_native/stylesheet/sheet_parser/parser/annotations.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser/annotations.ex
@@ -2,17 +2,11 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Annotations do
   alias LiveViewNative.Stylesheet.SheetParser.Parser.Context
   # Helpers
 
-  def context_to_annotation(%{context: %Context{} = context}, line) do
-    context_to_annotation(context, line)
+  def context_to_annotation(%{context: %Context{annotations: true} = context}, line) do
+    [file: context.file, line: line, module: context.module]
   end
 
-  if Mix.env() != :prod do
-    def context_to_annotation(%Context{} = context, line) do
-      [file: context.file, line: line, module: context.module]
-    end
-  else
-    def context_to_annotation(context, line) do
-      []
-    end
+  def context_to_annotation(_, _) do
+    []
   end
 end

--- a/lib/live_view_native/stylesheet/sheet_parser/parser/annotations.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser/annotations.ex
@@ -1,0 +1,18 @@
+defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Annotations do
+  alias LiveViewNative.Stylesheet.SheetParser.Parser.Context
+  # Helpers
+
+  def context_to_annotation(%{context: %Context{} = context}, line) do
+    context_to_annotation(context, line)
+  end
+
+  if Mix.env() != :prod do
+    def context_to_annotation(%Context{} = context, line) do
+      [file: context.file, line: line, module: context.module]
+    end
+  else
+    def context_to_annotation(context, line) do
+      []
+    end
+  end
+end

--- a/lib/live_view_native/stylesheet/sheet_parser/parser/context.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser/context.ex
@@ -1,24 +1,35 @@
 defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Context do
-  defstruct source: "",
-            errors: [],
-            file: "",
-            highlight_error: true,
-            module: nil,
-            # Where in the code does the input start?
-            # Useful for localizing errors when parsing sigil text
-            source_line: 1,
-            # When freezes is greater than 0, do not accept errors
-            freezes: 0
+  defstruct [
+    :file,
+    :annotations,
+    :module,
+    source: "",
+    errors: [],
+    highlight_error: true,
+    # Where in the code does the input start?
+    # Useful for localizing errors when parsing sigil text
+    source_line: 1,
+    # When freezes is greater than 0, do not accept errors
+    freezes: 0
+  ]
 
   def prepare_context(rest, args, context, {_line, _offset}, _byte_binary_offset) do
     {rest, args,
-     Map.put_new(context, :context, %__MODULE__{
+     context
+     |> Map.put_new(:context, %__MODULE__{
        source: rest,
        file: context[:file] || "",
        module: context[:module] || nil,
        source_line: context[:source_line] || 1,
-       highlight_error: Map.get(context, :highlight_error, true)
-     })}
+       highlight_error: Map.get(context, :highlight_error, true),
+       annotations: Map.get(context, :annotations, true)
+     })
+     |> Map.drop([
+       :file,
+       :module,
+       :source_line,
+       :highlight_error
+     ])}
   end
 
   def is_frozen?(%__MODULE__{freezes: freezes}), do: freezes > 0

--- a/lib/live_view_native/stylesheet/sheet_parser/parser/context.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser/context.ex
@@ -1,6 +1,4 @@
 defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Context do
-  alias __MODULE__
-
   defstruct source: "",
             errors: [],
             file: "",
@@ -14,7 +12,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Context do
 
   def prepare_context(rest, args, context, {_line, _offset}, _byte_binary_offset) do
     {rest, args,
-     Map.put_new(context, :context, %Context{
+     Map.put_new(context, :context, %__MODULE__{
        source: rest,
        file: context[:file] || "",
        module: context[:module] || nil,
@@ -23,10 +21,10 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Context do
      })}
   end
 
-  def is_frozen?(%Context{freezes: freezes}), do: freezes > 0
-  def is_frozen?(%{context: %Context{freezes: freezes}}), do: freezes > 0
-  def has_error?(%Context{errors: errors}), do: errors != []
-  def has_error?(%{context: %Context{errors: errors}}), do: errors != []
+  def is_frozen?(%__MODULE__{freezes: freezes}), do: freezes > 0
+  def is_frozen?(%{context: %__MODULE__{freezes: freezes}}), do: freezes > 0
+  def has_error?(%__MODULE__{errors: errors}), do: errors != []
+  def has_error?(%{context: %__MODULE__{errors: errors}}), do: errors != []
 
   def put_new_error(context, _rest, error) do
     if is_frozen?(context) and not error.forced? do

--- a/lib/live_view_native/stylesheet/sheet_parser/parser/context.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser/context.ex
@@ -1,0 +1,57 @@
+defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Context do
+  alias __MODULE__
+
+  defstruct source: "",
+            errors: [],
+            file: "",
+            highlight_error: true,
+            module: nil,
+            # Where in the code does the input start?
+            # Useful for localizing errors when parsing sigil text
+            source_line: 1,
+            # When freezes is greater than 0, do not accept errors
+            freezes: 0
+
+  def prepare_context(rest, args, context, {_line, _offset}, _byte_binary_offset) do
+    {rest, args,
+     Map.put_new(context, :context, %Context{
+       source: rest,
+       file: context[:file] || "",
+       module: context[:module] || nil,
+       source_line: context[:source_line] || 1,
+       highlight_error: Map.get(context, :highlight_error, true)
+     })}
+  end
+
+  def is_frozen?(%Context{freezes: freezes}), do: freezes > 0
+  def is_frozen?(%{context: %Context{freezes: freezes}}), do: freezes > 0
+  def has_error?(%Context{errors: errors}), do: errors != []
+  def has_error?(%{context: %Context{errors: errors}}), do: errors != []
+
+  def put_new_error(context, _rest, error) do
+    if is_frozen?(context) and not error.forced? do
+      context
+    else
+      path = [:context, Access.key(:errors)]
+
+      {_, context} =
+        get_and_update_in(context, path, fn
+          existing_errors -> {[error | existing_errors], [error | existing_errors]}
+        end)
+
+      context
+    end
+  end
+
+  def freeze_context(rest, args, context, {_line, _offset}, _byte_binary_offset) do
+    {_, context} = get_and_update_in(context, [:context, Access.key(:freezes)], &{&1, &1 + 1})
+    {rest, args, context}
+  end
+
+  def unfreeze_context(rest, args, context, {_line, _offset}, _byte_binary_offset) do
+    {_, context} =
+      get_and_update_in(context, [:context, Access.key(:freezes)], &{&1, max(0, &1 - 1)})
+
+    {rest, args, context}
+  end
+end

--- a/lib/live_view_native/stylesheet/sheet_parser/parser/error.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser/error.ex
@@ -1,0 +1,164 @@
+defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Error do
+  alias LiveViewNative.Stylesheet.SheetParser.Parser.Context
+  alias __MODULE__
+
+  defstruct([
+    :incorrect_text,
+    :show_incorrect_text?,
+    :line,
+    :byte_offset,
+    :error_message,
+    forced?: false
+  ])
+
+  def put_error(
+        rest,
+        args,
+        context,
+        _,
+        _,
+        error_message,
+        opts \\ []
+      )
+
+  def put_error(
+        rest,
+        [] = arg,
+        context,
+        {line, _offset},
+        byte_offset,
+        error_message,
+        opts
+      ) do
+    # IO.inspect({[], rest, error_message}, label: "error[0]")
+
+    context =
+      Context.put_new_error(context, rest, %Error{
+        incorrect_text: "",
+        line: line,
+        byte_offset: byte_offset,
+        error_message: error_message,
+        show_incorrect_text?: Keyword.get(opts, :show_incorrect_text?, false),
+        forced?: Keyword.get(opts, :force_error?, false)
+      })
+
+    {rest, arg, context}
+  end
+
+  def put_error(
+        rest,
+        [matched_text | _] = arg,
+        context,
+        {line, _offset},
+        byte_offset,
+        error_message,
+        opts
+      ) do
+    # IO.inspect({matched_text, rest, error_message}, label: "error[0]")
+
+    context =
+      Context.put_new_error(context, rest, %Error{
+        incorrect_text: matched_text,
+        line: line,
+        byte_offset: byte_offset,
+        error_message: error_message,
+        show_incorrect_text?: Keyword.get(opts, :show_incorrect_text?, false),
+        forced?: Keyword.get(opts, :force_error?, false)
+      })
+
+    {rest, arg, context}
+  end
+
+  def context_to_error_message(context) do
+    [%Error{} = error | _] = Enum.reverse(context.errors)
+
+    error_message = error.error_message
+    line = error.line
+    incorrect_text = error.incorrect_text
+    byte_offset = error.byte_offset
+
+    source_line =
+      (context.source_line || 1) + line - 1
+
+    error_text_length = String.length(incorrect_text)
+
+    before = String.slice(context.source, 0, max(0, byte_offset - error_text_length))
+    middle = String.slice(context.source, byte_offset - error_text_length, error_text_length)
+    middle = if(middle == " ", do: "_", else: middle)
+    # middle = if(middle == "", do: "▮", else: middle)
+    after_ = String.slice(context.source, byte_offset..-1//1)
+
+    highlight = fn code ->
+      if context.highlight_error do
+        IO.ANSI.format([:red, code])
+      else
+        code
+      end
+    end
+
+    source_lines =
+      [
+        before,
+        highlight.(middle),
+        case {after_, middle} do
+          {"", ""} ->
+            highlight.("_")
+
+          _ ->
+            after_
+        end
+      ]
+      |> IO.iodata_to_binary()
+      |> String.split("\n")
+      |> Enum.at(line - 1)
+      |> List.wrap()
+
+    error_lines =
+      [
+        String.replace(before, ~r/([^\n])/, " "),
+        highlight.(String.replace(middle, ~r/[^\n]/, "^")),
+        String.replace(after_, ~r/([^\n])/, " ")
+      ]
+      |> IO.iodata_to_binary()
+      |> String.split("\n")
+      |> Enum.at(line - 1)
+      |> List.wrap()
+
+    max_line_number = "#{source_line + Enum.count(error_lines) - 1}"
+    line_spacer = String.duplicate(" ", String.length(max_line_number))
+
+    lines =
+      Enum.zip(source_lines, error_lines)
+      |> Enum.with_index(source_line)
+      |> Enum.map(fn {{s_l, e_l}, line_num} ->
+        """
+        #{line_num} | #{s_l}
+        #{line_spacer} | #{e_l}
+        """
+        |> String.trim()
+      end)
+      |> Enum.join("\n")
+
+    maybe_but_got =
+      if error.show_incorrect_text? do
+        if String.ends_with?(error_message, "\n") do
+          "\nbut got ‘#{incorrect_text}’"
+        else
+          ", but got ‘#{incorrect_text}’"
+        end
+      else
+        ""
+      end
+
+    message = """
+    Invalid class block:
+    #{line_spacer} |
+    #{lines}
+    #{line_spacer} |
+
+    #{error_message}#{maybe_but_got}
+    """
+
+    {message, {source_line, 0}, error.byte_offset}
+  end
+end

--- a/lib/live_view_native/stylesheet/sheet_parser/parser/error.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser/error.ex
@@ -1,6 +1,5 @@
 defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Error do
   alias LiveViewNative.Stylesheet.SheetParser.Parser.Context
-  alias __MODULE__
 
   defstruct([
     :incorrect_text,
@@ -33,7 +32,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Error do
     # IO.inspect({[], rest, error_message}, label: "error[0]")
 
     context =
-      Context.put_new_error(context, rest, %Error{
+      Context.put_new_error(context, rest, %__MODULE__{
         incorrect_text: "",
         line: line,
         byte_offset: byte_offset,
@@ -57,7 +56,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Error do
     # IO.inspect({matched_text, rest, error_message}, label: "error[0]")
 
     context =
-      Context.put_new_error(context, rest, %Error{
+      Context.put_new_error(context, rest, %__MODULE__{
         incorrect_text: matched_text,
         line: line,
         byte_offset: byte_offset,
@@ -70,7 +69,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Error do
   end
 
   def context_to_error_message(context) do
-    [%Error{} = error | _] = Enum.reverse(context.errors)
+    [%__MODULE__{} = error | _] = Enum.reverse(context.errors)
 
     error_message = error.error_message
     line = error.line

--- a/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
@@ -1,38 +1,62 @@
 defmodule LiveViewNative.Stylesheet.SheetParser.PostProcessors do
-  def wrap_in_tuple(rest, args, context, _line, _offset) do
+  import LiveViewNative.Stylesheet.SheetParser.Parser.Annotations
+
+  def mark_line(rest, args, context, {line, _offset}, _byte_offset, name) do
+    {rest, args, Map.put(context, name, line)}
+  end
+
+  def unmark_line(rest, args, context, _line, _byte_offset, name) do
+    {rest, args, Map.delete(context, name)}
+  end
+
+  def wrap_in_tuple(rest, args, context, _line, _byte_offset) do
     {rest, [List.to_tuple(Enum.reverse(args))], context}
   end
 
-  def block_open_with_variable_to_ast(rest, [variable, string], context, _line, _offset) do
+  def block_open_with_variable_to_ast(rest, [variable, string], context, {line, _offset}, _offset) do
     {rest,
      [
-       {:<>, [context: Elixir, imports: [{2, Kernel}]], [string, variable]}
+       {:<>, context_to_annotation(context, line) ++ [context: Elixir, imports: [{2, Kernel}]],
+        [string, variable]}
      ], context}
   end
 
-  def block_open_to_ast(rest, [class_name], context, _line, _offset) do
-    {rest, [[class_name, {:_target, [], Elixir}]], context}
+  def block_open_to_ast(rest, [class_name], context, {line, _offset}, _byte_offset) do
+    {rest,
+     [
+       [
+         class_name,
+         {:_target, context_to_annotation(context, line), Elixir}
+       ]
+     ], context}
   end
 
-  def block_open_to_ast(rest, [key_value_pairs, class_name], context, _line, _offset) do
-    {rest, [[class_name, key_value_pairs]], context}
+  def block_open_to_ast(rest, [opts, class_name], context, {line, _}, _byte_offset) do
+    {rest, [[class_name, context_to_annotation(context, line) ++ opts]], context}
   end
 
-  def tag_as_elixir_code(rest, [quotable], context, _line, _offset) do
-    {rest, [{Elixir, [], quotable}], context}
+  def tag_as_elixir_code(rest, [quotable], context, {line, _offset}, _byte_offset) do
+    {rest,
+     [{Elixir, context_to_annotation(context, context[:open_elixir_code] || line), quotable}],
+     Map.delete(context, :open_elixir_code)}
   end
 
-  def to_elixir_variable_ast(rest, [variable_name], context, _line, _offset) do
-    {rest, [{String.to_atom(variable_name), [], Elixir}], context}
+  def to_elixir_variable_ast(rest, [variable_name], context, {line, _offset}, _byte_offset) do
+    {rest, [{String.to_atom(variable_name), context_to_annotation(context, line), Elixir}],
+     context}
   end
 
-  def to_keyword_tuple_ast(rest, [arg1, arg2], context, _line, _offset) do
+  def to_keyword_tuple_ast(rest, [arg1, arg2], context, _line, _byte_offset) do
     {rest, [{String.to_atom(arg2), arg1}], context}
   end
 
-  def to_function_call_ast(rest, args, context, _line, _offset) do
+  def to_function_call_ast(rest, args, context, {line, _offset}, _byte_offset) do
     [ast_name | other_args] = Enum.reverse(args)
 
-    {rest, [{String.to_atom(ast_name), [], other_args}], context}
+    {rest,
+     [
+       {String.to_atom(ast_name),
+        context_to_annotation(context, context[:open_function_line] || line), other_args}
+     ], Map.delete(context, :open_function_line)}
   end
 end

--- a/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
@@ -13,7 +13,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.PostProcessors do
     {rest, [List.to_tuple(Enum.reverse(args))], context}
   end
 
-  def block_open_with_variable_to_ast(rest, [variable, string], context, {line, _offset}, _offset) do
+  def block_open_with_variable_to_ast(rest, [variable, string], context, {line, _offset}, _byte_offset) do
     {rest,
      [
        {:<>, context_to_annotation(context, line) ++ [context: Elixir, imports: [{2, Kernel}]],

--- a/test/sheet_parser_test.exs
+++ b/test/sheet_parser_test.exs
@@ -4,6 +4,9 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
 
   alias LiveViewNative.Stylesheet.SheetParser
 
+  @file_name __ENV__.file
+  @module __MODULE__
+
   describe "SheetParser.parse" do
     test "with a single literal as the class name, default target is implied" do
       sheet = """
@@ -12,11 +15,14 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       end
       """
 
-      result = SheetParser.parse(sheet)
+      result = SheetParser.parse(sheet, file: @file_name, module: @module)
 
       assert result == [
-        {["color-red", {:_target, [], Elixir}], "color(.red)\n"}
-      ]
+               {[
+                  "color-red",
+                  {:_target, [file: @file_name, line: 1, module: @module], Elixir}
+                ], "color(.red)\n"}
+             ]
     end
 
     test "can parse multiple class blocks" do
@@ -30,12 +36,14 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       end
       """
 
-      result = SheetParser.parse(sheet)
+      result = SheetParser.parse(sheet, file: @file_name, module: @module)
 
       assert result == [
-        {["color-red", {:_target, [], Elixir}], "color(.red)\n"},
-        {["color-blue", {:_target, [], Elixir}], "color(.blue)\n"}
-      ]
+               {["color-red", {:_target, [file: @file_name, line: 1, module: @module], Elixir}],
+                "color(.red)\n"},
+               {["color-blue", {:_target, [file: @file_name, line: 5, module: @module], Elixir}],
+                "color(.blue)\n"}
+             ]
     end
 
     test "with pattern matching in the class name, default target is implied" do
@@ -46,26 +54,37 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       end
       """
 
-      result = SheetParser.parse(sheet)
+      result = SheetParser.parse(sheet, file: @file_name, module: @module)
 
       assert result == [
-        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, {:_target, [], Elixir}], "color(color: color_name)\nfoobar\n"}
-      ]
+               {[
+                  {:<>,
+                   [
+                     file: @file_name,
+                     line: 1,
+                     module: @module,
+                     context: Elixir,
+                     imports: [{2, Kernel}]
+                   ],
+                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], Elixir}]},
+                  {:_target, [file: @file_name, line: 1, module: @module], Elixir}
+                ], "color(color: color_name)\nfoobar\n"}
+             ]
     end
 
     test "with literal class name, target is defined" do
-
       sheet = """
       "color-red", target: :watch do
         color(.red)
       end
       """
 
-      result = SheetParser.parse(sheet)
+      result = SheetParser.parse(sheet, file: @file_name, module: @module)
 
       assert result == [
-        {["color-red", [target: :watch]], "color(.red)\n"}
-      ]
+               {["color-red", [file: @file_name, line: 1, module: @module, target: :watch]],
+                "color(.red)\n"}
+             ]
     end
 
     test "with pattern matching in the class name, target is defined" do
@@ -76,11 +95,61 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       end
       """
 
-      result = SheetParser.parse(sheet)
+      result = SheetParser.parse(sheet, file: @file_name, module: @module)
 
       assert result == [
-        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, [target: :tv]], "color(color: color_name)\nfoobar\n"}
-      ]
+               {[
+                  {:<>,
+                   [
+                     file: @file_name,
+                     line: 1,
+                     module: @module,
+                     context: Elixir,
+                     imports: [{2, Kernel}]
+                   ],
+                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], Elixir}]},
+                  [file: @file_name, line: 1, module: @module, target: :tv]
+                ], "color(color: color_name)\nfoobar\n"}
+             ]
+    end
+
+    test "raises compile error when block header is incorrect" do
+      sheet = """
+      "color-red" <> 1a do
+        color(.red)
+      end
+      """
+
+      assert_raise CompileError,
+                   ~r|^test/sheet_parser_test.exs:1: Invalid class block:|,
+                   fn ->
+                     SheetParser.parse(sheet, file: @file_name, module: @module)
+                   end
+
+      sheet = """
+      "color-red" <> do
+        color(.red)
+      end
+      """
+
+      assert_raise CompileError,
+                   ~r|^test/sheet_parser_test.exs:1: Invalid class block:|,
+                   fn ->
+                     SheetParser.parse(sheet, file: @file_name, module: @module)
+                   end
+    end
+
+    test "raises compile error when end is missing" do
+      sheet = """
+      "color-red" do
+        color(.red)
+      """
+
+      assert_raise CompileError,
+                   ~r|^test/sheet_parser_test.exs:3: Invalid class block:|,
+                   fn ->
+                     SheetParser.parse(sheet, file: @file_name, module: @module)
+                   end
     end
   end
 end

--- a/test/sheet_parser_test.exs
+++ b/test/sheet_parser_test.exs
@@ -25,6 +25,25 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
              ]
     end
 
+    test "annotations can be controlled from the config" do
+      sheet = """
+      "color-red" do
+        color(.red)
+      end
+      """
+
+      Application.put_env(:live_view_native_stylesheet, :annotations, false)
+      result = SheetParser.parse(sheet, file: @file_name, module: @module)
+      Application.delete_env(:live_view_native_stylesheet, :annotations)
+
+      assert result == [
+               {[
+                  "color-red",
+                  {:_target, [], Elixir}
+                ], "color(.red)\n"}
+             ]
+    end
+
     test "can parse multiple class blocks" do
       sheet = """
       "color-red" do


### PR DESCRIPTION
1. Added annotations to the sheet parser to identify the source file, module and line of a piece of AST
2. Added compile errors and tests for the sheet sigil. You can test it out by modifying the non-rule parts of `MockSheet` and trying to compile.

For example, the following should fail to compile:
```elixir
  ~SHEET"""
  "color-hex-" <> 31 do
    rule-31
    rule-22
  end

  "color-yellow" do
    rule-21
  end

  "named-argument" do
    rule-ime
  end
  """
```