### PR TITLE
Add comments to the mock sheet

### DIFF
--- a/test/mocks/mock_sheet.ex
+++ b/test/mocks/mock_sheet.ex
@@ -7,6 +7,8 @@ defmodule MockSheet do
     rule-22
   end
 
+  # this is a comment that isn't included in the output
+
   "color-yellow" do
     rule-21
   end


### PR DESCRIPTION
all lines beginning with `# ` should be considered comments and are not included in the output. Parser should ignore these