### PR TITLE
Include newlines in rules

### DIFF
--- a/lib/live_view_native/stylesheet/sheet_parser/block.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/block.ex
@@ -40,13 +40,13 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Block do
       )
       |> choice([
         string("\n")
-        |> ignore_whitespace(),
+        |> ignore(whitespace_except(?\n, min: 1)),
         ascii_string([], not: [], max: 1)
       ])
     )
     |> concat(whitespace(min: 1))
     |> reduce({Enum, :join, [""]})
-    |> map({String, :trim_leading, []})
+    |> map({String, :replace_prefix, ["\n", ""]})
 
   defcombinator(
     :class_block,

--- a/lib/live_view_native/stylesheet/sheet_parser/tokens.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/tokens.ex
@@ -62,7 +62,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Tokens do
   end
 
   def whitespace_except(exception, opts) do
-    utf8_string(Enum.reject(@whitespace_chars, &(<<&1>> == exception)), opts)
+    utf8_string(Enum.reject(@whitespace_chars, &(&1 == exception)), opts)
   end
 
   def ignore_whitespace(combinator \\ empty()) do

--- a/test/sheet_parser_test.exs
+++ b/test/sheet_parser_test.exs
@@ -11,7 +11,6 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
     test "with a single literal as the class name, default target is implied" do
       sheet = """
       "color-red" do
-
         color(.red)
       end
       """
@@ -22,7 +21,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                {[
                   "color-red",
                   {:_target, [file: @file_name, line: 1, module: @module], Elixir}
-                ], "\ncolor(.red)\n"}
+                ], "color(.red)\n"}
              ]
     end
 
@@ -52,6 +51,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       end
 
       "color-blue" do
+
         color(.blue)
       end
       """
@@ -62,7 +62,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                {["color-red", {:_target, [file: @file_name, line: 1, module: @module], Elixir}],
                 "color(.red)\n"},
                {["color-blue", {:_target, [file: @file_name, line: 5, module: @module], Elixir}],
-                "color(.blue)\n"}
+                "\ncolor(.blue)\n"}
              ]
     end
 

--- a/test/sheet_parser_test.exs
+++ b/test/sheet_parser_test.exs
@@ -11,6 +11,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
     test "with a single literal as the class name, default target is implied" do
       sheet = """
       "color-red" do
+
         color(.red)
       end
       """
@@ -21,7 +22,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                {[
                   "color-red",
                   {:_target, [file: @file_name, line: 1, module: @module], Elixir}
-                ], "color(.red)\n"}
+                ], "\ncolor(.red)\n"}
              ]
     end
 


### PR DESCRIPTION
The sheet parser should include leading newlines so that we can properly identify line numbers.

```
sheet = """
4 | "color-red" do
5 |
6 |  color(.red)
7 | end
8 | """
```

If we strip out the newline on line 5 and tell the rules parser that the rules started on line 5, the rules parser will see:
```
5 |  color(.red)
```

instead of

```
5 |
6 |  color(.red)
```

which will result in incorrectly placed errors.