### PR TITLE
Pass annotations down to rules parser

### DIFF
--- a/lib/live_view_native/stylesheet/sheet_parser.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser.ex
@@ -41,14 +41,16 @@ defmodule LiveViewNative.Stylesheet.SheetParser do
       |> LiveViewNative.Stylesheet.Utils.eval_quoted()
       |> LiveViewNative.Stylesheet.SheetParser.parse(
         file: __CALLER__.file,
-        module: __CALLER__.module,
-        line: __CALLER__.line + 1
+        line: __CALLER__.line + 1,
+        module: __CALLER__.module
       )
 
-    quote bind_quoted: [blocks: Macro.escape(blocks)] do
-      for {arguments, body} <- blocks do
+    for {arguments, opts, body} <- blocks do
+      quote bind_quoted: [arguments: Macro.escape(arguments), body: body, opts: opts] do
+        ast = LiveViewNative.Stylesheet.RulesParser.parse(body, @sheet_format, opts)
+
         def class(unquote_splicing(arguments)) do
-          sigil_RULES(unquote(body), nil)
+          unquote(ast)
         end
       end
     end

--- a/test/mocks/mock_rules_parser.ex
+++ b/test/mocks/mock_rules_parser.ex
@@ -7,33 +7,42 @@ defmodule MockRulesParser do
     end
   end
 
-  def parse(rules) do
+  def parse(rules, opts) do
     rules
     |> String.split("\n", trim: true)
-    |> Enum.map(&parse_rule(&1))
+    |> Enum.map(&parse_rule(&1, opts))
   end
 
-  defp parse_rule("rule-31") do
+  defp parse_rule("rule-31", _opts) do
     {:<>, [], ["rule-31-", {Elixir, [], {:number, [], Elixir}}]}
   end
 
-  defp parse_rule("rule-21") do
+  defp parse_rule("rule-21", _opts) do
     {:foobar, [], [1, 2, 3]}
   end
 
-  defp parse_rule("rule-22") do
+  defp parse_rule("rule-21-annotated", opts) do
+    {:foobar,
+     [
+       file: Keyword.get(opts, :file),
+       line: Keyword.get(opts, :line),
+       module: Keyword.get(opts, :module)
+     ], [1, 2, 3]}
+  end
+
+  defp parse_rule("rule-22", _opts) do
     {:foobar, [], [1, 2, {Elixir, [], {:number, [], Elixir}}]}
   end
 
-  defp parse_rule("rule-ime") do
+  defp parse_rule("rule-ime", _opts) do
     {:color, [], [color: [{:., [], [nil, :red]}]]}
   end
 
-  defp parse_rule("rule-" <> number) do
+  defp parse_rule("rule-" <> number, _) do
     number
     |> Integer.parse()
     |> elem(0)
   end
 
-  defp parse_rule(rule), do: rule
+  defp parse_rule(rule, _), do: rule
 end

--- a/test/rules_parser_test.exs
+++ b/test/rules_parser_test.exs
@@ -55,7 +55,7 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
       end
     end
 
-    test "will accept annotation data" do
+    test "will pass annotation data through to the rules parser" do
       rules = """
       rule-21-annotated
       rule-21

--- a/test/rules_parser_test.exs
+++ b/test/rules_parser_test.exs
@@ -4,6 +4,9 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
 
   alias LiveViewNative.Stylesheet.RulesParser
 
+  @file_name __ENV__.file
+  @module __ENV__.module
+
   describe "Rules.fetch_parser" do
     test "when a parser is available with the given format the designated parser module is returned" do
       {:ok, parser} = RulesParser.fetch(:mock)
@@ -51,12 +54,23 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
         RulesParser.parse("", :other)
       end
     end
+
+    test "will accept annotation data" do
+      rules = """
+      rule-21-annotated
+      rule-21
+      """
+
+      result = RulesParser.parse(rules, :mock, file: @file_name, line: 1, module: @module)
+
+      assert result == [
+               {:{}, [], [:foobar, [file: @file_name, line: 1, module: @module], [1, 2, 3]]},
+               {:{}, [], [:foobar, [], [1, 2, 3]]},
+             ]
+    end
   end
 
   describe "Rules.Helper.parse" do
-    @file_name __ENV__.file
-    @module __ENV__.module
-
     def annotation(line), do: [file: @file_name, line: line, module: @module]
 
     def parse_helper_function(source, opts \\ []) when is_list(opts) do

--- a/test/sheet_parser_test.exs
+++ b/test/sheet_parser_test.exs
@@ -21,6 +21,12 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                {[
                   "color-red",
                   {:_target, [file: @file_name, line: 1, module: @module], Elixir}
+                ],
+                [
+                  file: @file_name,
+                  line: 2,
+                  module: @module,
+                  annotations: true
                 ], "color(.red)\n"}
              ]
     end
@@ -41,6 +47,12 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                {[
                   "color-red",
                   {:_target, [file: @file_name, line: 2, module: @module], Elixir}
+                ],
+                [
+                  file: @file_name,
+                  line: 3,
+                  module: @module,
+                  annotations: true
                 ], "color(.red)\n# this is a comment will not be stripped\n"}
              ]
     end
@@ -60,7 +72,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                {[
                   "color-red",
                   {:_target, [], Elixir}
-                ], "color(.red)\n"}
+                ], [annotations: false], "color(.red)\n"}
              ]
     end
 
@@ -80,9 +92,19 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
 
       assert result == [
                {["color-red", {:_target, [file: @file_name, line: 1, module: @module], Elixir}],
-                "color(.red)\n"},
+                [
+                  file: @file_name,
+                  line: 2,
+                  module: @module,
+                  annotations: true
+                ], "color(.red)\n"},
                {["color-blue", {:_target, [file: @file_name, line: 5, module: @module], Elixir}],
-                "\ncolor(.blue)\n"}
+                [
+                  file: @file_name,
+                  line: 6,
+                  module: @module,
+                  annotations: true
+                ], "\ncolor(.blue)\n"}
              ]
     end
 
@@ -108,6 +130,12 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                    ],
                    ["color-", {:color_name, [file: @file_name, line: 1, module: @module], Elixir}]},
                   {:_target, [file: @file_name, line: 1, module: @module], Elixir}
+                ],
+                [
+                  file: @file_name,
+                  line: 2,
+                  module: @module,
+                  annotations: true
                 ], "color(color: color_name)\nfoobar\n"}
              ]
     end
@@ -123,7 +151,12 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
 
       assert result == [
                {["color-red", [file: @file_name, line: 1, module: @module, target: :watch]],
-                "color(.red)\n"}
+                [
+                  file: @file_name,
+                  line: 2,
+                  module: @module,
+                  annotations: true
+                ], "color(.red)\n"}
              ]
     end
 
@@ -149,6 +182,12 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                    ],
                    ["color-", {:color_name, [file: @file_name, line: 1, module: @module], Elixir}]},
                   [file: @file_name, line: 1, module: @module, target: :tv]
+                ],
+                [
+                  file: @file_name,
+                  line: 2,
+                  module: @module,
+                  annotations: true
                 ], "color(color: color_name)\nfoobar\n"}
              ]
     end


### PR DESCRIPTION
In order for the Rules parsers to provide good annotations, we need to pass block level information from the sheet parser. 


```swift
1 | "color-red" do
2 |   color(.red)
3 | end
4 | 
5 | "color-blue" do
6 | 
7 |   color(.blue)
8 | end
```
For example given the above sheet:
- the rules parser of the first class needs to know that it starts on line 2
- the second needs to know that it starts on line 6

Additionally, both parsers will need to know the `file` and `module` the rules are defined in as well as the whether or not `annotations` should be shown.

--- 
Once merged, we will be able to report rule errors with complete location information