### PR TITLE
Fix parsing blocks containing the substring "end"

### DIFF
--- a/test/mocks/mock_rules_parser.ex
+++ b/test/mocks/mock_rules_parser.ex
@@ -38,6 +38,10 @@ defmodule MockRulesParser do
     {:color, [], [color: [{:., [], [nil, :red]}]]}
   end
 
+  defp parse_rule("rule-end", _) do
+    {:foobar, [], [1, 2]}
+  end
+
   defp parse_rule("rule-" <> number, _) do
     number
     |> Integer.parse()

--- a/test/mocks/mock_sheet.ex
+++ b/test/mocks/mock_sheet.ex
@@ -13,6 +13,10 @@ defmodule MockSheet do
     rule-21
   end
 
+  "rule containing end" do
+    rule-end
+  end
+
   "named-argument" do
     rule-ime
   end

--- a/test/sheet_parser_test.exs
+++ b/test/sheet_parser_test.exs
@@ -27,7 +27,31 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                   line: 2,
                   module: @module,
                   annotations: true
-                ], "color(.red)\n"}
+                ], "color(.red)"}
+             ]
+    end
+
+    test "the token end is ignored unless it is prefixed by a whitespace and suffixed by a whitespace or eos" do
+      sheet = """
+      "color-red" do
+        rule-end
+        end-rule
+      end
+      """
+
+      result = SheetParser.parse(sheet, file: @file_name, module: @module)
+
+      assert result == [
+               {[
+                  "color-red",
+                  {:_target, [file: @file_name, line: 1, module: @module], Elixir}
+                ],
+                [
+                  file: @file_name,
+                  line: 2,
+                  module: @module,
+                  annotations: true
+                ], "rule-end\nend-rule"}
              ]
     end
 
@@ -53,7 +77,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                   line: 3,
                   module: @module,
                   annotations: true
-                ], "color(.red)\n# this is a comment will not be stripped\n"}
+                ], "color(.red)\n# this is a comment will not be stripped"}
              ]
     end
 
@@ -72,7 +96,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                {[
                   "color-red",
                   {:_target, [], Elixir}
-                ], [annotations: false], "color(.red)\n"}
+                ], [annotations: false], "color(.red)"}
              ]
     end
 
@@ -97,14 +121,14 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                   line: 2,
                   module: @module,
                   annotations: true
-                ], "color(.red)\n"},
+                ], "color(.red)"},
                {["color-blue", {:_target, [file: @file_name, line: 5, module: @module], Elixir}],
                 [
                   file: @file_name,
                   line: 6,
                   module: @module,
                   annotations: true
-                ], "\ncolor(.blue)\n"}
+                ], "\ncolor(.blue)"}
              ]
     end
 
@@ -136,7 +160,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                   line: 2,
                   module: @module,
                   annotations: true
-                ], "color(color: color_name)\nfoobar\n"}
+                ], "color(color: color_name)\nfoobar"}
              ]
     end
 
@@ -156,7 +180,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                   line: 2,
                   module: @module,
                   annotations: true
-                ], "color(.red)\n"}
+                ], "color(.red)"}
              ]
     end
 
@@ -188,7 +212,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                   line: 2,
                   module: @module,
                   annotations: true
-                ], "color(color: color_name)\nfoobar\n"}
+                ], "color(color: color_name)\nfoobar"}
              ]
     end
 
@@ -225,7 +249,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       """
 
       assert_raise CompileError,
-                   ~r|^test/sheet_parser_test.exs:3: Invalid class block:|,
+                   ~r|^test/sheet_parser_test.exs:2: Invalid class block:|,
                    fn ->
                      SheetParser.parse(sheet, file: @file_name, module: @module)
                    end


### PR DESCRIPTION
The following would fail because renderingMode contains the word "end". 
The block parser now requires that "end" be surrounded by whitespace or whitespace and an end of string.

```elixir
  "multi-modifier-class" do
    resizable(capInsets: EdgeInsets(top: 20, leading: 30, bottom: 20, trailing: 20), resizingMode: .tile)
    renderingMode(.template)
  end
```