### PR TITLE
Fix variable capture in RULES sigil

### DIFF
--- a/lib/live_view_native/stylesheet/rules_parser.ex
+++ b/lib/live_view_native/stylesheet/rules_parser.ex
@@ -10,7 +10,8 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
         opts = [
           file: __CALLER__.file,
           line: __CALLER__.line + 1,
-          module: __CALLER__.module
+          module: __CALLER__.module,
+          context: nil
         ]
 
         LiveViewNative.Stylesheet.RulesParser.parse(rules, unquote(format), opts)
@@ -34,7 +35,7 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
         body
         |> LiveViewNative.Stylesheet.Utils.eval_quoted()
         |> String.replace("\r\n", "\n")
-        |> parser.parse(opts)
+        |> parser.parse(Keyword.put_new(opts, :context, Elixir))
         |> List.wrap()
         |> Enum.map(&escape(&1))
       {:error, message} -> raise message

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -38,6 +38,24 @@ defmodule LiveViewNative.StylesheetTest do
     assert output == %{"single" => [{:single, [], [1]}]}
   end
 
+  test "can compile custom classes using the RULES sigil" do
+    output = MockSheet.compile_ast("custom-multi-123-456")
+
+    assert output == %{"custom-multi-123-456" => [
+      {:foobar, [], [1, 2, 123]},
+      {:bazqux, [], [3, 4, 456]}
+    ]}
+  end
+
+  test "can compile custom classes using the RULES sigil (2)" do
+    output = MockSheet.compile_ast("custom-123")
+
+    assert output == %{"custom-123" => [{:foobar, [], [1, 2, 123]}]}
+
+    output = MockSheet.compile_ast("custom-124")
+    assert output == %{"custom-124" => [{:foobar, [], [1, 2, 124]}]}
+  end
+
   describe "LiveViewNative.Stylesheet sigil" do
     test "single rules supported" do
       output = MockSheet.compile_ast(["color-yellow"], target: :all)

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -39,21 +39,21 @@ defmodule LiveViewNative.StylesheetTest do
   end
 
   test "can compile custom classes using the RULES sigil" do
-    output = MockSheet.compile_ast("custom-multi-123-456")
-
-    assert output == %{"custom-multi-123-456" => [
-      {:foobar, [], [1, 2, 123]},
-      {:bazqux, [], [3, 4, 456]}
-    ]}
-  end
-
-  test "can compile custom classes using the RULES sigil (2)" do
     output = MockSheet.compile_ast("custom-123")
 
     assert output == %{"custom-123" => [{:foobar, [], [1, 2, 123]}]}
 
     output = MockSheet.compile_ast("custom-124")
     assert output == %{"custom-124" => [{:foobar, [], [1, 2, 124]}]}
+  end
+
+  test "can compile custom classes using the RULES sigil (2)" do
+    output = MockSheet.compile_ast("custom-multi-123-456")
+
+    assert output == %{"custom-multi-123-456" => [
+      {:foobar, [], [1, 2, 123]},
+      {:bazqux, [], [3, 4, 456]}
+    ]}
   end
 
   describe "LiveViewNative.Stylesheet sigil" do

--- a/test/mocks/mock_rules_parser.ex
+++ b/test/mocks/mock_rules_parser.ex
@@ -13,8 +13,8 @@ defmodule MockRulesParser do
     |> Enum.map(&parse_rule(&1, opts))
   end
 
-  defp parse_rule("rule-31", _opts) do
-    {:<>, [], ["rule-31-", {Elixir, [], {:number, [], Elixir}}]}
+  defp parse_rule("rule-31", opts) do
+    {:<>, [], ["rule-31-", {Elixir, [], {:number, [], Keyword.get(opts, :context)}}]}
   end
 
   defp parse_rule("rule-21", _opts) do
@@ -30,8 +30,12 @@ defmodule MockRulesParser do
      ], [1, 2, 3]}
   end
 
-  defp parse_rule("rule-22", _opts) do
-    {:foobar, [], [1, 2, {Elixir, [], {:number, [], Elixir}}]}
+  defp parse_rule("rule-22", opts) do
+    {:foobar, [], [1, 2, {Elixir, [], {:number, [], Keyword.get(opts, :context)}}]}
+  end
+
+  defp parse_rule("rule-23", opts) do
+    {:bazqux, [], [3, 4, {Elixir, [], {:number2, [], Keyword.get(opts, :context)}}]}
   end
 
   defp parse_rule("rule-ime", _opts) do

--- a/test/mocks/mock_sheet.ex
+++ b/test/mocks/mock_sheet.ex
@@ -42,6 +42,24 @@ defmodule MockSheet do
   def class("single", _target) do
     {:single, [], [1]}
   end
+  def class("custom-multi-" <> numbers, _target) do
+    [number, number2] = String.split(numbers, "-")
+    {number, ""} = Integer.parse(number)
+    {number2, ""} = Integer.parse(number2)
+
+    ~RULES"""
+    rule-22
+    rule-23
+    """
+  end
+
+  def class("custom-" <> number, _target) do
+    {number, ""} = Integer.parse(number)
+
+    ~RULES"""
+    rule-22
+    """
+  end
 
   def class(unmatched, target: target) do
     {:unmatched, "Stylesheet warning: Could not match on class: #{inspect(unmatched)} for target: #{inspect(target)}"}

--- a/test/mocks/mock_sheet.ex
+++ b/test/mocks/mock_sheet.ex
@@ -42,6 +42,7 @@ defmodule MockSheet do
   def class("single", _target) do
     {:single, [], [1]}
   end
+
   def class("custom-multi-" <> numbers, _target) do
     [number, number2] = String.split(numbers, "-")
     {number, ""} = Integer.parse(number)


### PR DESCRIPTION
Use the `nil` context for `RULES` and the `Elixir` context for `SHEET`s.

In the `SHEET` sigil, we generate functions. A referenced variable must be in scope., this is enforced by `Elixir`.
```elixir
  ~SHEET"""
  "color-hex-" <> number do
    rule-31
    rule-22
  end
  """
```
This sigil generates the entire function and so the `number` in the function header will be visible to the `number` produced by `rule-22`

---

In the `RULES` sigil, a referenced variable doesn't need to be in the SIGIL so we use `nil`.
```elixir
  def class("custom-" <> number, _target) do
    {number, ""} = Integer.parse(number)

    ~RULES"""
    rule-22
    """
  end
```
This sigil generates the an ast that references the `number` variable in the function header. Because the variable is defined outside the macro, it will not be visible in the context of the macro. We use a `nil` context to mark the variable as being available in the "outer" context.
