### PR TITLE
Rename `context` to `variable_context` to avoid name collision with parser context

### DIFF
--- a/lib/live_view_native/stylesheet/rules_parser.ex
+++ b/lib/live_view_native/stylesheet/rules_parser.ex
@@ -11,7 +11,7 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
           file: __CALLER__.file,
           line: __CALLER__.line + 1,
           module: __CALLER__.module,
-          context: nil
+          variable_context: nil
         ]
 
         LiveViewNative.Stylesheet.RulesParser.parse(rules, unquote(format), opts)
@@ -35,7 +35,7 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
         body
         |> LiveViewNative.Stylesheet.Utils.eval_quoted()
         |> String.replace("\r\n", "\n")
-        |> parser.parse(Keyword.put_new(opts, :context, Elixir))
+        |> parser.parse(Keyword.put_new(opts, :variable_context, Elixir))
         |> List.wrap()
         |> Enum.map(&escape(&1))
       {:error, message} -> raise message

--- a/test/mocks/mock_rules_parser.ex
+++ b/test/mocks/mock_rules_parser.ex
@@ -14,7 +14,7 @@ defmodule MockRulesParser do
   end
 
   defp parse_rule("rule-31", opts) do
-    {:<>, [], ["rule-31-", {Elixir, [], {:number, [], Keyword.get(opts, :context)}}]}
+    {:<>, [], ["rule-31-", {Elixir, [], {:number, [], Keyword.get(opts, :variable_context)}}]}
   end
 
   defp parse_rule("rule-21", _opts) do
@@ -31,11 +31,11 @@ defmodule MockRulesParser do
   end
 
   defp parse_rule("rule-22", opts) do
-    {:foobar, [], [1, 2, {Elixir, [], {:number, [], Keyword.get(opts, :context)}}]}
+    {:foobar, [], [1, 2, {Elixir, [], {:number, [], Keyword.get(opts, :variable_context)}}]}
   end
 
   defp parse_rule("rule-23", opts) do
-    {:bazqux, [], [3, 4, {Elixir, [], {:number2, [], Keyword.get(opts, :context)}}]}
+    {:bazqux, [], [3, 4, {Elixir, [], {:number2, [], Keyword.get(opts, :variable_context)}}]}
   end
 
   defp parse_rule("rule-ime", _opts) do


### PR DESCRIPTION
Resolve collisions discovered when updating the SwiftUI rules parser