### PR TITLE
Add `to_number`

### DIFF
--- a/lib/live_view_native/stylesheet/rules_helpers.ex
+++ b/lib/live_view_native/stylesheet/rules_helpers.ex
@@ -13,8 +13,9 @@ defmodule LiveViewNative.Stylesheet.RulesHelpers do
     try do
       {integer, ""} = Integer.parse(expr)
       integer
-    catch _ ->
-      to_float(expr)
+    rescue
+      _ ->
+        to_float(expr)
     end
   end
 

--- a/lib/live_view_native/stylesheet/rules_helpers.ex
+++ b/lib/live_view_native/stylesheet/rules_helpers.ex
@@ -15,7 +15,13 @@ defmodule LiveViewNative.Stylesheet.RulesHelpers do
       integer
     rescue
       _ ->
-        to_float(expr)
+      try do
+        {float, ""} = Float.parse(expr)
+        float
+      rescue
+        _ ->
+        expr
+      end
     end
   end
 

--- a/lib/live_view_native/stylesheet/rules_helpers.ex
+++ b/lib/live_view_native/stylesheet/rules_helpers.ex
@@ -9,6 +9,15 @@ defmodule LiveViewNative.Stylesheet.RulesHelpers do
     Float.parse(expr) |> elem(0)
   end
 
+  def to_number(expr) when is_binary(expr) do
+    try do
+      {integer, ""} = Integer.parse(expr)
+      integer
+    catch _ ->
+      to_float(expr)
+    end
+  end
+
   def to_boolean("true"), do: true
   def to_boolean("false"), do: false
 


### PR DESCRIPTION
The new `#{variable}` syntax required for SwiftUI expects a  float or integer variable.

To support both, we first attempt to convert the entire expr into an integer, if that fails we try converting it into a float.

---

If the variable is not a number, we return the original string. 

For example if we had the following rule:
```elixir
"h-" <> height do
  height(#{height})
end
```

The class `h-abc` would produce the ast for `height("abc")` and it would be up to the client to detect the error.