### PR TITLE
EEx interpolation

### DIFF
--- a/lib/live_view_native/stylesheet/rules_parser.ex
+++ b/lib/live_view_native/stylesheet/rules_parser.ex
@@ -1,21 +1,16 @@
 defmodule LiveViewNative.Stylesheet.RulesParser do
-  @callback parse(rules :: binary, opts :: keyword()) :: list
-  @macrocallback __using__(format :: atom) :: tuple
+  defmacro sigil_RULES({:<<>>, _meta, [rules]}, _modifier) do
+    opts = [
+      file: __CALLER__.file,
+      line: __CALLER__.line + 1,
+      module: __CALLER__.module,
+      variable_context: nil
+    ]
 
-  defmacro __using__(format) do
+    compiled_rules = EEx.compile_string(rules)
+
     quote do
-      @behaviour LiveViewNative.Stylesheet.RulesParser
-
-      defmacro sigil_RULES(rules, _modifier) do
-        opts = [
-          file: __CALLER__.file,
-          line: __CALLER__.line + 1,
-          module: __CALLER__.module,
-          variable_context: nil
-        ]
-
-        LiveViewNative.Stylesheet.RulesParser.parse(rules, unquote(format), opts)
-      end
+      LiveViewNative.Stylesheet.RulesParser.parse(unquote(compiled_rules), @format, unquote(opts))
     end
   end
 
@@ -32,32 +27,15 @@ defmodule LiveViewNative.Stylesheet.RulesParser do
   def parse(body, format, opts \\ []) do
     case fetch(format) do
       {:ok, parser} ->
-        opts = opts
+        opts =
+          opts
           |> Keyword.put_new(:variable_context, Elixir)
           |> Keyword.update(:file, "", &Path.basename/1)
           
         body
-        |> LiveViewNative.Stylesheet.Utils.eval_quoted()
         |> String.replace("\r\n", "\n")
         |> parser.parse(opts)
-        |> List.wrap()
-        |> Enum.map(&escape(&1))
       {:error, message} -> raise message
     end
   end
-
-  defp escape({operator, meta, arguments}) when operator in [:<>] do
-    {operator, meta, Enum.map(arguments, &escape(&1))}
-  end
-  defp escape({Elixir, _meta, expr}), do: expr
-  defp escape({identity, annotations, arguments}) do
-    {:{}, [], [identity, annotations, escape(arguments)]}
-  end
-  defp escape([{key, value} | tail]) do
-    [{key, escape(value)} | escape(tail)]
-  end
-  defp escape([argument | tail]) do
-    [escape(argument) | escape(tail)]
-  end
-  defp escape(literal), do: literal
 end

--- a/lib/live_view_native/stylesheet/sheet_parser.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser.ex
@@ -44,12 +44,10 @@ defmodule LiveViewNative.Stylesheet.SheetParser do
         module: __CALLER__.module
       )
 
-    for {arguments, opts, body} <- blocks do
-      quote bind_quoted: [arguments: Macro.escape(arguments), body: body, opts: opts] do
-        ast = LiveViewNative.Stylesheet.RulesParser.parse(body, @native_opts[:format], opts)
-
+    for {arguments, _opts, body} <- blocks do
+      quote do
         def class(unquote_splicing(arguments)) do
-          unquote(ast)
+          sigil_RULES(<<unquote(body)>>, [])
         end
       end
     end

--- a/lib/live_view_native/stylesheet/sheet_parser/parser/error.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/parser/error.ex
@@ -29,7 +29,6 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Error do
         error_message,
         opts
       ) do
-    # IO.inspect({[], rest, error_message}, label: "error[0]")
 
     context =
       Context.put_new_error(context, rest, %__MODULE__{
@@ -53,7 +52,6 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Parser.Error do
         error_message,
         opts
       ) do
-    # IO.inspect({matched_text, rest, error_message}, label: "error[0]")
 
     context =
       Context.put_new_error(context, rest, %__MODULE__{

--- a/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
@@ -16,7 +16,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.PostProcessors do
   def block_open_with_variable_to_ast(rest, [variable, string], context, {line, _offset}, _byte_offset) do
     {rest,
      [
-       {:<>, context_to_annotation(context, line) ++ [context: Elixir, imports: [{2, Kernel}]],
+       {:<>, context_to_annotation(context, line) ++ [context: nil, imports: [{2, Kernel}]],
         [string, variable]}
      ], context}
   end
@@ -26,7 +26,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.PostProcessors do
      [
        [
          class_name,
-         {:_target, context_to_annotation(context, line), Elixir}
+         {:_target, context_to_annotation(context, line), nil}
        ]
      ], context}
   end
@@ -42,7 +42,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.PostProcessors do
   end
 
   def to_elixir_variable_ast(rest, [variable_name], context, {line, _offset}, _byte_offset) do
-    {rest, [{String.to_atom(variable_name), context_to_annotation(context, line), Elixir}],
+    {rest, [{String.to_atom(variable_name), context_to_annotation(context, line), nil}],
      context}
   end
 

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -3,15 +3,15 @@ defmodule LiveViewNative.StylesheetTest do
   doctest LiveViewNative.Stylesheet
 
   test "will compile the rules for all listed classes" do
-    output = MockSheet.compile_ast(["color-blue", "color-red"], target: nil)
+    output = MockSheet.compile_ast(["color-blue", "color-yellow"], target: nil)
 
-    assert output == %{"color-blue" => [2], "color-red" => [1,3,4]}
+    assert output == %{"color-blue" => ["rule-2"], "color-yellow" => ["rule-yellow"]}
   end
 
   test "will compile the rules for a specific target" do
-    output = MockSheet.compile_ast(["color-blue", "color-red"], target: :watch)
+    output = MockSheet.compile_ast(["color-blue", "color-yellow"], target: :watch)
 
-    assert output == %{"color-blue" => [4,5], "color-red" => [1,3,4]}
+    assert output == %{"color-blue" => ["rule-5"], "color-yellow" => ["rule-yellow"]}
   end
 
   test "won't fail when an class name isn't found" do
@@ -21,58 +21,43 @@ defmodule LiveViewNative.StylesheetTest do
   end
 
   test "can compile without target, will default to `target: :all`" do
-    output = MockSheet.compile_ast(["color-blue", "color-red"])
+    output = MockSheet.compile_ast(["color-blue", "color-yellow"])
 
-    assert output == %{"color-blue" => [2], "color-red" => [1,3,4]}
+    assert output == %{"color-blue" => ["rule-2"], "color-yellow" => ["rule-yellow"]}
   end
 
   test "can compile for a single class name" do
     output = MockSheet.compile_ast("color-blue")
 
-    assert output == %{"color-blue" => [2]}
-  end
-
-  test "can compile when a rule set is not a list" do
-    output = MockSheet.compile_ast("single")
-
-    assert output == %{"single" => [{:single, [], [1]}]}
+    assert output == %{"color-blue" => ["rule-2"]}
   end
 
   test "can compile custom classes using the RULES sigil" do
-    output = MockSheet.compile_ast("custom-123")
+    output = MockSheet.compile_ast("custom-123-456")
 
-    assert output == %{"custom-123" => [{:foobar, [], [1, 2, 123]}]}
+    assert output == %{"custom-123-456" => ["rule-123", "rule-456"]}
 
-    output = MockSheet.compile_ast("custom-124")
-    assert output == %{"custom-124" => [{:foobar, [], [1, 2, 124]}]}
-  end
-
-  test "can compile custom classes using the RULES sigil (2)" do
-    output = MockSheet.compile_ast("custom-multi-123-456")
-
-    assert output == %{"custom-multi-123-456" => [
-      {:foobar, [], [1, 2, 123]},
-      {:bazqux, [], [3, 4, 456]}
-    ]}
+    output = MockSheet.compile_ast("custom-789-123")
+    assert output == %{"custom-789-123" => ["rule-789", "rule-123"]}
   end
 
   describe "LiveViewNative.Stylesheet sigil" do
     test "single rules supported" do
       output = MockSheet.compile_ast(["color-yellow"], target: :all)
 
-      assert output == %{"color-yellow" => [{:foobar, [], [1, 2, 3]}]}
+      assert output == %{"color-yellow" => ["rule-yellow"]}
     end
 
     test "multiple rules and class name pattern matching" do
-      output = MockSheet.compile_ast(["color-hex-123"], target: :all)
+      output = MockSheet.compile_ast(["color-number-4"], target: :all)
 
-      assert output == %{"color-hex-123" => ["rule-31-123", {:foobar, [], [1, 2, "123"]}]}
+      assert output == %{"color-number-4" => ["rule-1", "rule-24"]}
     end
 
     test "can convert the output to a string" do
-      output = MockSheet.compile_string(["color-hex-123"])
+      output = MockSheet.compile_string(["color-number-3"])
 
-      assert output == ~s(%{"color-hex-123" => ["rule-31-123", {:foobar, [], [1, 2, "123"]}]})
+      assert output == ~s(%{"color-number-3" => ["rule-1", "rule-23"]})
     end
   end
 end

--- a/test/rules_parser_test.exs
+++ b/test/rules_parser_test.exs
@@ -31,23 +31,7 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
 
       result = RulesParser.parse(rules, :mock)
 
-      assert result == [1, 2]
-    end
-
-    test "will rewrite parsed rules for macro escape but will hoist Elixir terms" do
-      rules = """
-      rule-21
-      rule-22
-      rule-ime
-      """
-
-      result = RulesParser.parse(rules, :mock)
-
-      assert result == [
-               {:{}, [], [:foobar, [], [1, 2, 3]]},
-               {:{}, [], [:foobar, [], [1, 2, {:number, [], Elixir}]]},
-               {:{}, [], [:color, [], [color: [{:{}, [], [:., [], [nil, :red]]}]]]}
-             ]
+      assert result == ["rule-1", "rule-2"]
     end
 
     test "will raise when parser is not found" do
@@ -58,15 +42,13 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
 
     test "will pass annotation data through to the rules parser" do
       rules = """
-      rule-21-annotated
-      rule-21
+      rule-annotated
       """
 
       result = RulesParser.parse(rules, :mock, file: @file_path, line: 1, module: @module)
 
       assert result == [
-               {:{}, [], [:foobar, [file: @file_name, line: 1, module: @module], [1, 2, 3]]},
-               {:{}, [], [:foobar, [], [1, 2, 3]]},
+               {:foobar, [file: @file_name, line: 1, module: @module], [1, 2, 3]}
              ]
     end
   end
@@ -95,7 +77,7 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
       input = "to_float(number)"
 
       output =
-        {Elixir, annotation(1), {:to_float, annotation(1), [{:number, annotation(1), Elixir}]}}
+        {Elixir, annotation(1), {:to_float, annotation(1), [{:number, annotation(1), nil}]}}
 
       assert {:ok, [result], _, _, _, _} =
                parse_helper_function(input, file: @file_path, module: @module)
@@ -107,7 +89,7 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
       input = "to_abc(family)"
 
       output =
-        {Elixir, annotation(1), {:to_abc, annotation(1), [{:family, annotation(1), Elixir}]}}
+        {Elixir, annotation(1), {:to_abc, annotation(1), [{:family, annotation(1), nil}]}}
 
       assert {:ok, [result], _, _, _, _} =
                parse_helper_function(input, file: @file_path, module: @module)
@@ -121,7 +103,7 @@ defmodule LiveViewNative.Stylesheet.RulesParserTest do
         )"
 
       output =
-        {Elixir, annotation(1), {:to_abc, annotation(1), [{:family, annotation(2), Elixir}]}}
+        {Elixir, annotation(1), {:to_abc, annotation(1), [{:family, annotation(2), nil}]}}
 
       assert {:ok, [result], _, _, _, _} =
                parse_helper_function(input, file: @file_path, module: @module)

--- a/test/sheet_parser_test.exs
+++ b/test/sheet_parser_test.exs
@@ -37,7 +37,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       assert result == [
                {[
                   "color-red",
-                  {:_target, [file: @file_name, line: 1, module: @module], Elixir}
+                  {:_target, [file: @file_name, line: 1, module: @module], nil}
                 ],
                 [
                   file: @file_name,
@@ -62,7 +62,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       assert result == [
                {[
                   "color-red",
-                  {:_target, [file: @file_name, line: 1, module: @module], Elixir}
+                  {:_target, [file: @file_name, line: 1, module: @module], nil}
                 ],
                 [
                   file: @file_name,
@@ -89,7 +89,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       assert result == [
                {[
                   "color-red",
-                  {:_target, [file: @file_name, line: 2, module: @module], Elixir}
+                  {:_target, [file: @file_name, line: 2, module: @module], nil}
                 ],
                 [
                   file: @file_name,
@@ -114,7 +114,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       assert result == [
                {[
                   "color-red",
-                  {:_target, [], Elixir}
+                  {:_target, [], nil}
                 ], [annotations: false], "color(.red)"}
              ]
     end
@@ -135,14 +135,14 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       result = SheetParser.parse(sheet, file: @file_path, module: @module)
 
       assert result == [
-               {["color-red", {:_target, [file: @file_name, line: 1, module: @module], Elixir}],
+               {["color-red", {:_target, [file: @file_name, line: 1, module: @module], nil}],
                 [
                   file: @file_name,
                   line: 2,
                   module: @module,
                   annotations: true
                 ], "color(.red)"},
-               {["color-blue", {:_target, [file: @file_name, line: 5, module: @module], Elixir}],
+               {["color-blue", {:_target, [file: @file_name, line: 5, module: @module], nil}],
                 [
                   file: @file_name,
                   line: 6,
@@ -170,11 +170,11 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                      file: @file_name,
                      line: 1,
                      module: @module,
-                     context: Elixir,
+                     context: nil,
                      imports: [{2, Kernel}]
                    ],
-                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], Elixir}]},
-                  {:_target, [file: @file_name, line: 1, module: @module], Elixir}
+                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], nil}]},
+                  {:_target, [file: @file_name, line: 1, module: @module], nil}
                 ],
                 [
                   file: @file_name,
@@ -224,10 +224,10 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                      file: @file_name,
                      line: 1,
                      module: @module,
-                     context: Elixir,
+                     context: nil,
                      imports: [{2, Kernel}]
                    ],
-                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], Elixir}]},
+                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], nil}]},
                   [file: @file_name, line: 1, module: @module, target: :tv]
                 ],
                 [

--- a/test/support/mock_rules_parser.ex
+++ b/test/support/mock_rules_parser.ex
@@ -1,55 +1,17 @@
 defmodule MockRulesParser do
-  use LiveViewNative.Stylesheet.RulesParser, :mock
-
-  defmacro __using__(_) do
-    quote do
-      import MockRulesParser, only: [sigil_RULES: 2]
-    end
-  end
-
   def parse(rules, opts) do
     rules
     |> String.split("\n", trim: true)
     |> Enum.map(&parse_rule(&1, opts))
   end
 
-  defp parse_rule("rule-31", opts) do
-    {:<>, [], ["rule-31-", {Elixir, [], {:number, [], Keyword.get(opts, :variable_context)}}]}
-  end
-
-  defp parse_rule("rule-21", _opts) do
-    {:foobar, [], [1, 2, 3]}
-  end
-
-  defp parse_rule("rule-21-annotated", opts) do
+  defp parse_rule("rule-annotated", opts) do
     {:foobar,
      [
        file: Keyword.get(opts, :file),
        line: Keyword.get(opts, :line),
        module: Keyword.get(opts, :module)
      ], [1, 2, 3]}
-  end
-
-  defp parse_rule("rule-22", opts) do
-    {:foobar, [], [1, 2, {Elixir, [], {:number, [], Keyword.get(opts, :variable_context)}}]}
-  end
-
-  defp parse_rule("rule-23", opts) do
-    {:bazqux, [], [3, 4, {Elixir, [], {:number2, [], Keyword.get(opts, :variable_context)}}]}
-  end
-
-  defp parse_rule("rule-ime", _opts) do
-    {:color, [], [color: [{:., [], [nil, :red]}]]}
-  end
-
-  defp parse_rule("rule-end", _) do
-    {:foobar, [], [1, 2]}
-  end
-
-  defp parse_rule("rule-" <> number, _) do
-    number
-    |> Integer.parse()
-    |> elem(0)
   end
 
   defp parse_rule(rule, _), do: rule

--- a/test/support/mock_sheet.ex
+++ b/test/support/mock_sheet.ex
@@ -2,27 +2,23 @@ defmodule MockSheet do
   use LiveViewNative.Stylesheet, :mock
 
   ~SHEET"""
-  "color-hex-" <> number do
-    rule-31
-    rule-22
+  "color-number-" <> number do
+    rule-1
+    rule-2<%= number %>
   end
 
   # this is a comment that isn't included in the output
 
   "color-yellow" do
-    rule-21
+    rule-yellow
   end
 
   "rule containing end" do
     rule-end
   end
-
-  "named-argument" do
-    rule-ime
-  end
   """
 
-  def class("color-red", _target) do
+  def class("color-three", _target) do
     ~RULES"""
     rule-1
     rule-3
@@ -32,7 +28,6 @@ defmodule MockSheet do
 
   def class("color-blue", target: :watch) do
     ~RULES"""
-    rule-4
     rule-5
     """
   end
@@ -43,30 +38,14 @@ defmodule MockSheet do
     """
   end
 
-  def class("single", _target) do
-    {:single, [], [1]}
-  end
-
-  def class("custom-multi-" <> numbers, _target) do
-    [number, number2] = String.split(numbers, "-")
-    {number, ""} = Integer.parse(number)
-    {number2, ""} = Integer.parse(number2)
+  def class("custom-" <> numbers, _target) do
+    [number_1, number_2] = String.split(numbers, "-")
+    {number_1, ""} = Integer.parse(number_1)
+    {number_2, ""} = Integer.parse(number_2)
 
     ~RULES"""
-    rule-22
-    rule-23
+    rule-<%= number_1 %>
+    rule-<%= number_2 %>
     """
-  end
-
-  def class("custom-" <> number, _target) do
-    {number, ""} = Integer.parse(number)
-
-    ~RULES"""
-    rule-22
-    """
-  end
-
-  def class(unmatched, target: target) do
-    {:unmatched, "Stylesheet warning: Could not match on class: #{inspect(unmatched)} for target: #{inspect(target)}"}
   end
 end


### PR DESCRIPTION
Introduces EEx interpolation on the rules document prior to passing to the format specific parser. This means there is a two-phase process.

The tests were also simplified. As `~RULES` is now simply only responsible for interpolating with EEx then passing the resulting document to the format specific rules parser. We didn't need the rules tests in this lilb.

This means we can drop the idea of "helpers" as we can execute Elixir code in the EEx interpolation:

```heex
"frame:" <> dims do
  frame(height: <%= String.split(dims, ":") |> List.first() %>, width: <%= String.split(dims, ":") |> List.last() %>)
end
``

and because it's just Elixir we can extract these into function helpers in the sheet itself:

```elixir
defmodule MySheet do
  use LiveViewNative.Stylesheet, :swiftui

  ~SHEET"""
  "frame:" <> dims do
    frame(height: <%= extract_dim(dims, 0) %>, width: <%= extract_dim(dims, 1) %>)
  end
  """

  defp extract_dims(dims, index) do
    dims
    |> String.split("-")
    |> Enum.at(index)
  end
end
```