### PR TITLE
Format paths and re-render fix

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -6,6 +6,9 @@ config :live_view_native, :plugins, [
 
 config :live_view_native_stylesheet,
   content: [
-    "test/**/*.*"
+    mock: [
+      "test/**/*.*",
+      {:live_view_native, "lib/**/*.*"}
+    ]
   ],
   output: "priv/static/assets"

--- a/lib/live_view_native/stylesheet/component.ex
+++ b/lib/live_view_native/stylesheet/component.ex
@@ -16,21 +16,29 @@ defmodule LiveViewNative.Stylesheet.Component do
   """
   defmacro embed_stylesheet(stylesheet_module) do
     stylesheet_module = Macro.expand(stylesheet_module, __CALLER__)
+    format = stylesheet_module.__native_opts__[:format]
 
-    extracted_class_names = LiveViewNative.Stylesheet.Extractor.run()
+    {files, class_names} = LiveViewNative.Stylesheet.Extractor.run(format)
 
-    compiled_sheet_string = stylesheet_module.compile_string(extracted_class_names)
-    compiled_sheet_ast = stylesheet_module.compile_ast(extracted_class_names)
+    compiled_sheet_string = stylesheet_module.compile_string(class_names)
+    compiled_sheet_ast = stylesheet_module.compile_ast(class_names)
 
     quote do
+      for file <- unquote(files) do
+        @external_resource file
+      end
+
       # this function is mostly intended for debugging purposes
       # it isn't intended to be used directly in your application code
-      def __stylsheet_ast__ do
+      def __stylesheet_ast__ do
         unquote(Macro.escape(compiled_sheet_ast))
       end
 
       def stylesheet(var!(assigns)) do
-        sheet = unquote(compiled_sheet_string)
+        sheet =
+          unquote(compiled_sheet_string)
+          |> Phoenix.HTML.raw()
+
         var!(assigns) = Map.put(var!(assigns), :sheet, sheet)
 
         ~LVN"""


### PR DESCRIPTION
Now the path patterns will be looked up via the format, so each format can declare it's own path pattern. For example:

```elixir
config :live_view_native_stylesheet, content: [
  swiftui: [
    "lib/**/*swiftui*",
    {:live_view_native_swiftui_components, "lib/**/*"}
  ],
  jetpack: [
    "lib/**/*jetpack*"
  ]
]
```

This will allow for greater control over the pattern to prevent bloating of the stylesheet for class names that may share names between platforms but aren't being used.

In addition, this also introduces extracting class names from deps. You just add `{otp_name, pattern}` and the dep's paths will be scanned.

This PR also fixes stylesheets not being re-rendered if the template changed. Now the layout component that the stylesheet is being compiled into will have all of the files that match the patterns provided as `@external_resource`