### PR TITLE
Change class/2 to class/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3
+
+* removed `_interface` argument from the `class/2` now it is `class/1`
+
 # v0.1
 
 Initial release in prep for eventual v0.2

--- a/lib/live_view_native/stylesheet.ex
+++ b/lib/live_view_native/stylesheet.ex
@@ -13,12 +13,12 @@ defmodule LiveViewNative.Stylesheet do
       @format unquote(format)
       @before_compile LiveViewNative.Stylesheet
 
-      def compile_ast(class_or_list, target \\ [target: :all])
-      def compile_ast(class_or_list, target: target) do
+      def compile_ast(class_or_list)
+      def compile_ast(class_or_list) do
         class_or_list
         |> List.wrap()
         |> Enum.reduce(%{}, fn(class_name, class_map) ->
-          case class(class_name, target: target) do
+          case class(class_name) do
             {:unmatched, msg} -> class_map
             rules ->
               Map.put(class_map, class_name, List.wrap(rules))
@@ -26,7 +26,7 @@ defmodule LiveViewNative.Stylesheet do
         end)
       end
 
-      def compile_string(class_or_list, target \\ [target: :all]) do
+      def compile_string(class_or_list) do
         pretty = Application.get_env(:live_view_native_stylesheet, :pretty, false)
 
         class_or_list
@@ -47,8 +47,8 @@ defmodule LiveViewNative.Stylesheet do
     quote do
       def __sheet_path__, do: unquote(sheet_path)
 
-      def class(unmatched, target: target) do
-        {:unmatched, "Stylesheet warning: Could not match on class: #{inspect(unmatched)} for target: #{inspect(target)}"}
+      def class(unmatched) do
+        {:unmatched, "Stylesheet warning: Could not match on class: #{inspect(unmatched)}"}
       end
     end
   end

--- a/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/post_processors.ex
@@ -21,14 +21,8 @@ defmodule LiveViewNative.Stylesheet.SheetParser.PostProcessors do
      ], context}
   end
 
-  def block_open_to_ast(rest, [class_name], context, {line, _offset}, _byte_offset) do
-    {rest,
-     [
-       [
-         class_name,
-         {:_target, context_to_annotation(context, line), nil}
-       ]
-     ], context}
+  def block_open_to_ast(rest, [class_name], context, {_line, _offset}, _byte_offset) do
+    {rest, [[class_name]], context}
   end
 
   def block_open_to_ast(rest, [opts, class_name], context, {line, _}, _byte_offset) do

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -19,27 +19,15 @@ defmodule LiveViewNative.StylesheetTest do
   end
 
   test "will compile the rules for all listed classes" do
-    output = MockSheet.compile_ast(["color-blue", "color-yellow"], target: nil)
-
-    assert output == %{"color-blue" => ["rule-2"], "color-yellow" => ["rule-yellow"]}
-  end
-
-  test "will compile the rules for a specific target" do
-    output = MockSheet.compile_ast(["color-blue", "color-yellow"], target: :watch)
-
-    assert output == %{"color-blue" => ["rule-5"], "color-yellow" => ["rule-yellow"]}
-  end
-
-  test "won't fail when an class name isn't found" do
-    output = MockSheet.compile_ast(["foobar"], target: :watch)
-
-    assert output == %{}
-  end
-
-  test "can compile without target, will default to `target: :all`" do
     output = MockSheet.compile_ast(["color-blue", "color-yellow"])
 
     assert output == %{"color-blue" => ["rule-2"], "color-yellow" => ["rule-yellow"]}
+  end
+
+  test "won't fail when an class name isn't found" do
+    output = MockSheet.compile_ast(["foobar"])
+
+    assert output == %{}
   end
 
   test "can compile for a single class name" do
@@ -59,13 +47,13 @@ defmodule LiveViewNative.StylesheetTest do
 
   describe "LiveViewNative.Stylesheet sigil" do
     test "single rules supported" do
-      output = MockSheet.compile_ast(["color-yellow"], target: :all)
+      output = MockSheet.compile_ast(["color-yellow"])
 
       assert output == %{"color-yellow" => ["rule-yellow"]}
     end
 
     test "multiple rules and class name pattern matching" do
-      output = MockSheet.compile_ast(["color-number-4"], target: :all)
+      output = MockSheet.compile_ast(["color-number-4"])
 
       assert output == %{"color-number-4" => ["rule-1", "rule-24"]}
     end

--- a/test/sheet_parser_test.exs
+++ b/test/sheet_parser_test.exs
@@ -24,7 +24,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
 
   describe "SheetParser.parse" do
     @annotations true
-    test "with a single literal as the class name, default target is implied" do
+    test "with a single literal as the class name" do
       sheet = """
       "color-red" do
         color(.red)
@@ -35,8 +35,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
 
       assert result == [
                {[
-                  "color-red",
-                  {:_target, [file: @file_name, line: 1, module: @module], nil}
+                  "color-red"
                 ],
                 [
                   file: @file_name,
@@ -60,8 +59,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
 
       assert result == [
                {[
-                  "color-red",
-                  {:_target, [file: @file_name, line: 1, module: @module], nil}
+                  "color-red"
                 ],
                 [
                   file: @file_name,
@@ -87,8 +85,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
 
       assert result == [
                {[
-                  "color-red",
-                  {:_target, [file: @file_name, line: 2, module: @module], nil}
+                  "color-red"
                 ],
                 [
                   file: @file_name,
@@ -110,12 +107,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       result = SheetParser.parse(sheet, file: @file_path, module: @module)
       Application.delete_env(:live_view_native_stylesheet, :annotations)
 
-      assert result == [
-               {[
-                  "color-red",
-                  {:_target, [], nil}
-                ], [annotations: false], "color(.red)"}
-             ]
+      assert result == [{["color-red"], [annotations: false], "color(.red)"}]
     end
 
     @annotations true
@@ -134,14 +126,14 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       result = SheetParser.parse(sheet, file: @file_path, module: @module)
 
       assert result == [
-               {["color-red", {:_target, [file: @file_name, line: 1, module: @module], nil}],
+               {["color-red"],
                 [
                   file: @file_name,
                   line: 2,
                   module: @module,
                   annotations: true
                 ], "color(.red)"},
-               {["color-blue", {:_target, [file: @file_name, line: 5, module: @module], nil}],
+               {["color-blue"],
                 [
                   file: @file_name,
                   line: 6,
@@ -152,7 +144,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
     end
 
     @annotations true
-    test "with pattern matching in the class name, default target is implied" do
+    test "with pattern matching in the class name" do
       sheet = """
       "color-" <> color_name do
         color(color: color_name)
@@ -172,8 +164,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
                      context: nil,
                      imports: [{2, Kernel}]
                    ],
-                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], nil}]},
-                  {:_target, [file: @file_name, line: 1, module: @module], nil}
+                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], nil}]}
                 ],
                 [
                   file: @file_name,
@@ -185,9 +176,9 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
     end
 
     @annotations true
-    test "with literal class name, target is defined" do
+    test "with literal class name" do
       sheet = """
-      "color-red", target: :watch do
+      "color-red" do
         color(.red)
       end
       """
@@ -195,46 +186,13 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       result = SheetParser.parse(sheet, file: @file_path, module: @module)
 
       assert result == [
-               {["color-red", [file: @file_name, line: 1, module: @module, target: :watch]],
+               {["color-red"],
                 [
                   file: @file_name,
                   line: 2,
                   module: @module,
                   annotations: true
                 ], "color(.red)"}
-             ]
-    end
-
-    @annotations true
-    test "with pattern matching in the class name, target is defined" do
-      sheet = """
-      "color-" <> color_name, target: :tv do
-        color(color: color_name)
-        foobar
-      end
-      """
-
-      result = SheetParser.parse(sheet, file: @file_path, module: @module)
-
-      assert result == [
-               {[
-                  {:<>,
-                   [
-                     file: @file_name,
-                     line: 1,
-                     module: @module,
-                     context: nil,
-                     imports: [{2, Kernel}]
-                   ],
-                   ["color-", {:color_name, [file: @file_name, line: 1, module: @module], nil}]},
-                  [file: @file_name, line: 1, module: @module, target: :tv]
-                ],
-                [
-                  file: @file_name,
-                  line: 2,
-                  module: @module,
-                  annotations: true
-                ], "color(color: color_name)\nfoobar"}
              ]
     end
   end

--- a/test/support/mock_sheet.ex
+++ b/test/support/mock_sheet.ex
@@ -18,7 +18,7 @@ defmodule MockSheet do
   end
   """
 
-  def class("color-three", _target) do
+  def class("color-three") do
     ~RULES"""
     rule-1
     rule-3
@@ -26,19 +26,13 @@ defmodule MockSheet do
     """
   end
 
-  def class("color-blue", target: :watch) do
-    ~RULES"""
-    rule-5
-    """
-  end
-
-  def class("color-blue", _target) do
+  def class("color-blue") do
     ~RULES"""
     rule-2
     """
   end
 
-  def class("custom-" <> numbers, _target) do
+  def class("custom-" <> numbers) do
     [number_1, number_2] = String.split(numbers, "-")
 
     ~RULES"""


### PR DESCRIPTION
Because we are now compiling the stylesheets at application compile-time we no longer am able to pass in any interface information to `class`.

Instead if a any specific stylsheet rules should exist that override another classname just create a new stylesheet and layout for that target