### PR TITLE
Capture and log raises within `class/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v0.3
 
+* capture and log raises within `class/1` call when compiling stylesheet
 * removed `_interface` argument from the `class/2` now it is `class/1`
 
 # v0.1

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,5 @@
 import Config
 
+config :logger, :level, :debug
+
 import_config "#{config_env()}.exs"

--- a/lib/live_view_native/stylesheet.ex
+++ b/lib/live_view_native/stylesheet.ex
@@ -18,8 +18,17 @@ defmodule LiveViewNative.Stylesheet do
         class_or_list
         |> List.wrap()
         |> Enum.reduce(%{}, fn(class_name, class_map) ->
-          case class(class_name) do
-            {:unmatched, msg} -> class_map
+          try do
+            class(class_name)
+          rescue
+            e ->
+              require Logger
+              Logger.error(Exception.format(:error, e, __STACKTRACE__))
+              {:error, nil}
+          end
+          |> case do
+            {:error, _msg} -> class_map
+            {:unmatched, _msg} -> class_map
             rules ->
               Map.put(class_map, class_name, List.wrap(rules))
           end

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -1,5 +1,6 @@
 defmodule LiveViewNative.StylesheetTest do
   use ExUnit.Case
+  import ExUnit.CaptureIO
   doctest LiveViewNative.Stylesheet
 
   describe "embed_stylesheet" do
@@ -43,6 +44,13 @@ defmodule LiveViewNative.StylesheetTest do
 
     output = MockSheet.compile_ast("custom-789-123")
     assert output == %{"custom-789-123" => ["rule-789", "rule-123"]}
+  end
+
+  test "will capture and log any raises within `class/1` when compiling stylesheet" do
+    assert capture_io(:user, fn ->
+      assert MockSheet.compile_ast(["raise-12"]) == %{}
+      Logger.flush()
+    end) =~ "no match of right hand side value: [\"12\"]"
   end
 
   describe "LiveViewNative.Stylesheet sigil" do

--- a/test/support/mock_sheet.ex
+++ b/test/support/mock_sheet.ex
@@ -40,4 +40,13 @@ defmodule MockSheet do
     rule-{ number_2 }
     """
   end
+
+  def class("raise-" <> numbers) do
+    [number_1, number_2] = String.split(numbers, ":")
+
+    ~RULES"""
+    rule-{ number_1 }
+    rule-{ number_2 }
+    """
+  end
 end


### PR DESCRIPTION
We shouldn't crash stylesheet compilation with malformed classnames