### PR TITLE
Ensure local components and slots express style attr

### DIFF
--- a/lib/live_view_native/stylesheet/extractor.ex
+++ b/lib/live_view_native/stylesheet/extractor.ex
@@ -113,7 +113,8 @@ defmodule LiveViewNative.Stylesheet.Extractor do
 
     tokens
     |> Enum.reduce([], fn
-      {:tag, _, attributes, _}, acc -> parse_style_from_attributes(attributes) ++ acc
+      {type, _, attributes, _}, acc when type in [:tag, :slot, :local_component] ->
+        parse_style_from_attributes(attributes) ++ acc
       _other, acc -> acc
     end)
     |> Enum.map(&({&1, path}))

--- a/test/live_view_native/stylesheet/integrations/mock_sheet_test.exs
+++ b/test/live_view_native/stylesheet/integrations/mock_sheet_test.exs
@@ -28,6 +28,9 @@ defmodule MockSheetTest do
       assert styles["c-bracket-3"] == ["c-bracket-3"]
       assert styles["c-bracket-4"] == ["c-bracket-4"]
 
+      assert styles["c-slot-string-1"] == ["c-slot-string-1"]
+      assert styles["c-local-component-string-1"] == ["c-local-component-string-1"]
+
       refute Map.has_key?(styles, "c-illegal")
     end
 
@@ -44,6 +47,9 @@ defmodule MockSheetTest do
       assert styles["t-bracket-\"2\""] == ["t-bracket-\"2\""]
       assert styles["t-bracket-3"] == ["t-bracket-3"]
       assert styles["t-bracket-4"] == ["t-bracket-4"]
+
+      assert styles["t-slot-string-1"] == ["t-slot-string-1"]
+      assert styles["t-local-component-string-1"] == ["t-local-component-string-1"]
 
       refute Map.has_key?(styles, "t-illegal")
     end

--- a/test/support/mock_render_component.ex
+++ b/test/support/mock_render_component.ex
@@ -14,10 +14,21 @@ defmodule MockRenderComponent do
   end
 
   def modal(assigns) do
+    assigns = Map.put(assigns, :style, "c-assign-1")
+
     ~LVN"""
     style="c-illegal"
     <Text style="c-string-2;c-string-3"/>
     <Text style="c-string-1;;; ;"/>
+    <.image style="c-local-component-string-1">
+      <:success style="c-slot-string-1"/>
+    </.image>
+    """
+  end
+
+  def image(assigns) do
+    ~LVN"""
+    <image></image>
     """
   end
 end

--- a/test/support/mock_template.neex
+++ b/test/support/mock_template.neex
@@ -8,3 +8,6 @@
 ~S(t-bracket-4)
 ]}/>
 style="t-illegal"
+<.image style="t-local-component-string-1">
+  <:success style="t-slot-string-1"/>
+</.image>


### PR DESCRIPTION
This should fix for the following:

```heex
<Text style="aaa"/>
<.image style="bbb">
  <:success style="ccc"/>
</.image>
```