### PR TITLE
Allow configuration of additional formats for style attr parsing

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -13,4 +13,9 @@ config :live_view_native_stylesheet,
       {:live_view_native, "lib/**/*.*"}
     ]
   ],
-  output: "priv/static/assets"
+  output: "priv/static/assets",
+  attribute_parsers: [
+    style: [
+      other: &LiveViewNative.Stylesheet.Extractor.parse_style/2
+    ]
+  ]

--- a/test/live_view_native/stylesheet/integrations/mock_sheet_test.exs
+++ b/test/live_view_native/stylesheet/integrations/mock_sheet_test.exs
@@ -55,5 +55,14 @@ defmodule MockSheetTest do
 
       refute Map.has_key?(styles, "t-illegal")
     end
+
+    test "parses from other file types defined in config" do
+      {styles, _} =
+        File.read!("priv/static/assets/mock_sheet.styles")
+        |> Code.eval_string()
+
+
+      assert styles["t-other-1"] == ["t-other-1"]
+    end
   end
 end

--- a/test/support/template.other
+++ b/test/support/template.other
@@ -1,0 +1,1 @@
+<Text style="t-other-1">Hello</Text>


### PR DESCRIPTION
This allows for additional file formats beyond the default of `neex` and `ex` files for parsing `style` attributes from