### PR TITLE
Fix the line number for rules produced inside a `sigil_SHEET`

### DIFF
--- a/lib/live_view_native/stylesheet/rules_parser.ex
+++ b/lib/live_view_native/stylesheet/rules_parser.ex
@@ -1,10 +1,15 @@
 defmodule LiveViewNative.Stylesheet.RulesParser do
   @moduledoc false
 
-  defmacro sigil_RULES({:<<>>, _meta, [rules]}, _modifier) do
+  defmacro sigil_RULES({:<<>>, _meta, [rules]}, opts) do
     opts = [
       file: __CALLER__.file,
-      line: __CALLER__.line + 1,
+      line:
+        if is_list(opts) && is_integer(Keyword.get(opts, :line)) do
+          Keyword.get(opts, :line)
+        else
+          __CALLER__.line + 1
+        end,
       module: __CALLER__.module,
       variable_context: nil
     ]

--- a/lib/live_view_native/stylesheet/sheet_parser.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser.ex
@@ -46,10 +46,10 @@ defmodule LiveViewNative.Stylesheet.SheetParser do
         module: __CALLER__.module
       )
 
-    for {arguments, _opts, body} <- blocks do
+    for {arguments, opts, body} <- blocks do
       quote do
         def class(unquote_splicing(arguments)) do
-          sigil_RULES(<<unquote(body)>>, [])
+          sigil_RULES(<<unquote(body)>>, unquote(opts))
         end
       end
     end

--- a/lib/live_view_native/stylesheet/sheet_parser/block.ex
+++ b/lib/live_view_native/stylesheet/sheet_parser/block.ex
@@ -101,6 +101,7 @@ defmodule LiveViewNative.Stylesheet.SheetParser.Block do
         ]
       else
         [
+          line: context.block_line,
           annotations: context.context.annotations
         ]
       end

--- a/test/live_view_native/stylesheet/sheet_parser_test.exs
+++ b/test/live_view_native/stylesheet/sheet_parser_test.exs
@@ -107,7 +107,7 @@ defmodule LiveViewNative.Stylesheet.SheetParserTest do
       result = SheetParser.parse(sheet, file: @file_path, module: @module)
       Application.delete_env(:live_view_native_stylesheet, :annotations)
 
-      assert result == [{["color-red"], [annotations: false], "color(.red)"}]
+      assert result == [{["color-red"], [line: 2, annotations: false], "color(.red)"}]
     end
 
     @annotations true


### PR DESCRIPTION
Required to fix bug in https://github.com/liveview-native/liveview-client-swiftui/pull/1402.

---

Currently, the `sigil_SHEET` parses blocks and hands the block contents to a `sigil_RULES`. We don't pass down any line information to the `sigil_RULES`. The parser used by the `sigil_RULES` will not receive information about the location of the block contents it is parsing. 

In the sheet below, the rules parser will treat `rule-blue` and `rule-yellow` as though they are at the same location. Both are assumed to be on line 3 (1 (Location of sheet parser) + 1 (location of block in sheet) + 1 (location of rule in block)).

```elixir
1 | ~SHEET"""
2 | "color-blue" do
3 |   rule-blue
4 | end
5 | 
6 | "color-yellow" do
7 |   rule-yellow
8 | end
9 | """
 ```
 
This PR passes block line information from the sheet parser down to the rules parser which allows for more correct errors and warnings. In the example above, `rule-blue` will be on line 3 and `rule-yellow` on line 7.
