### PR TITLE
Change stylesheet output to JSON

### DIFF
--- a/lib/live_view_native/stylesheet.ex
+++ b/lib/live_view_native/stylesheet.ex
@@ -160,11 +160,18 @@ defmodule LiveViewNative.Stylesheet do
 
         {class_or_list, style_list}
         |> compile_ast()
-        |> Jason.encode!(pretty: pretty)
+        |> Jason.encode(pretty: pretty)
       end
 
       def compile_string(class_or_list) do
         compile_string({class_or_list, []})
+      end
+
+      def compile_string!(input) do
+        case compile_string(input) do
+          {:ok, result} -> result
+          {:error, error} -> raise error
+        end
       end
     end
   end
@@ -288,7 +295,7 @@ defmodule LiveViewNative.Stylesheet do
         compiled_sheet =
           native_opts
           |> LiveViewNative.Stylesheet.Extractor.run()
-          |> module.compile_string()
+          |> module.compile_string!()
 
         file_path = Path.join(output, native_opts[:filename])
 

--- a/lib/live_view_native/stylesheet.ex
+++ b/lib/live_view_native/stylesheet.ex
@@ -160,36 +160,11 @@ defmodule LiveViewNative.Stylesheet do
 
         {class_or_list, style_list}
         |> compile_ast()
-        |> ast_to_json(pretty)
+        |> Jason.encode!(pretty: pretty)
       end
 
       def compile_string(class_or_list) do
         compile_string({class_or_list, []})
-      end
-
-      def ast_to_json(ast, _pretty) do
-        # TODO: Make use of pretty printing once supported in
-        # erlang
-
-        ast
-        |> :json.encode(&ast_encoder/2)
-        |> IO.iodata_to_binary()
-      end
-
-      defp ast_encoder(nil, encode) do
-        :json.encode_value(:null, encode)
-      end
-
-      defp ast_encoder(value, encode) when is_tuple(value) do
-        :json.encode_list(Tuple.to_list(value), encode)
-      end
-
-      defp ast_encoder([{_, _} | _] = value, encode) do
-        :json.encode_key_value_list(value, encode)
-      end
-
-      defp ast_encoder(other, encode) do
-        :json.encode_value(other, encode)
       end
     end
   end

--- a/lib/live_view_native/stylesheet.ex
+++ b/lib/live_view_native/stylesheet.ex
@@ -160,13 +160,37 @@ defmodule LiveViewNative.Stylesheet do
 
         {class_or_list, style_list}
         |> compile_ast()
-        |> inspect(limit: :infinity, charlists: :as_list, printable_limit: :infinity, pretty: pretty)
+        |> ast_to_json(pretty)
       end
 
       def compile_string(class_or_list) do
         compile_string({class_or_list, []})
       end
 
+      def ast_to_json(ast, _pretty) do
+        # TODO: Make use of pretty printing once supported in
+        # erlang
+
+        ast
+        |> :json.encode(&ast_encoder/2)
+        |> IO.iodata_to_binary()
+      end
+
+      defp ast_encoder(nil, encode) do
+        :json.encode_value(:null, encode)
+      end
+
+      defp ast_encoder(value, encode) when is_tuple(value) do
+        :json.encode_list(Tuple.to_list(value), encode)
+      end
+
+      defp ast_encoder([{_, _} | _] = value, encode) do
+        :json.encode_key_value_list(value, encode)
+      end
+
+      defp ast_encoder(other, encode) do
+        :json.encode_value(other, encode)
+      end
     end
   end
 

--- a/test/live_view_native/stylesheet/integrations/mock_sheet_test.exs
+++ b/test/live_view_native/stylesheet/integrations/mock_sheet_test.exs
@@ -5,7 +5,7 @@ defmodule MockSheetTest do
     test "will compile the stylesheet into an asset file" do
       styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> :json.decode()
+        |> Jason.decode!()
 
       assert styles["color-blue"] == ["rule-2"]
       assert styles["color-number-3"] == ["rule-1", "rule-23"]
@@ -17,7 +17,7 @@ defmodule MockSheetTest do
     test "parses from elixir files containing ~LVN templates" do
       styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> :json.decode()
+        |> Jason.decode!()
 
       assert styles["c-string-1"] == ["c-string-1"]
       assert styles["c-string-2"] == ["c-string-2"]
@@ -37,7 +37,7 @@ defmodule MockSheetTest do
     test "parses from template files" do
       styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> :json.decode()
+        |> Jason.decode!()
 
       assert styles["t-string-1"] == ["t-string-1"]
       assert styles["t-string-2"] == ["t-string-2"]
@@ -59,7 +59,7 @@ defmodule MockSheetTest do
     test "parses from other file types defined in config" do
       styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> :json.decode()
+        |> Jason.decode!()
 
       assert styles["t-other-1"] == ["t-other-1"]
     end
@@ -67,7 +67,7 @@ defmodule MockSheetTest do
     test "parses class and styles" do
       styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> :json.decode()
+        |> Jason.decode!()
 
       assert styles["c-class-1"] == ["c-rules-1"]
       assert styles["c-style-1"] == ["c-style-1"]

--- a/test/live_view_native/stylesheet/integrations/mock_sheet_test.exs
+++ b/test/live_view_native/stylesheet/integrations/mock_sheet_test.exs
@@ -3,9 +3,9 @@ defmodule MockSheetTest do
 
   describe "stylesheet output" do
     test "will compile the stylesheet into an asset file" do
-      {styles, _} =
+      styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> Code.eval_string()
+        |> :json.decode()
 
       assert styles["color-blue"] == ["rule-2"]
       assert styles["color-number-3"] == ["rule-1", "rule-23"]
@@ -15,9 +15,9 @@ defmodule MockSheetTest do
 
   describe "style parsing" do
     test "parses from elixir files containing ~LVN templates" do
-      {styles, _} =
+      styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> Code.eval_string()
+        |> :json.decode()
 
       assert styles["c-string-1"] == ["c-string-1"]
       assert styles["c-string-2"] == ["c-string-2"]
@@ -35,9 +35,9 @@ defmodule MockSheetTest do
     end
 
     test "parses from template files" do
-      {styles, _} =
+      styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> Code.eval_string()
+        |> :json.decode()
 
       assert styles["t-string-1"] == ["t-string-1"]
       assert styles["t-string-2"] == ["t-string-2"]
@@ -57,17 +57,17 @@ defmodule MockSheetTest do
     end
 
     test "parses from other file types defined in config" do
-      {styles, _} =
+      styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> Code.eval_string()
+        |> :json.decode()
 
       assert styles["t-other-1"] == ["t-other-1"]
     end
 
     test "parses class and styles" do
-      {styles, _} =
+      styles =
         File.read!("priv/static/assets/mock_sheet.styles")
-        |> Code.eval_string()
+        |> :json.decode()
 
       assert styles["c-class-1"] == ["c-rules-1"]
       assert styles["c-style-1"] == ["c-style-1"]

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -59,7 +59,7 @@ defmodule LiveViewNative.StylesheetTest do
     test "can convert the output to a string" do
       output = MockSheet.compile_string(["color-number-3"])
 
-      assert output == ~s({"color-number-3":["rule-1","rule-23"]})
+      assert output == {:ok, ~s({"color-number-3":["rule-1","rule-23"]})}
     end
 
     test "will not pattern match on nil or empty string" do

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -59,7 +59,7 @@ defmodule LiveViewNative.StylesheetTest do
     test "can convert the output to a string" do
       output = MockSheet.compile_string(["color-number-3"])
 
-      assert output == ~s(%{"color-number-3" => ["rule-1", "rule-23"]})
+      assert output == ~s({"color-number-3":["rule-1","rule-23"]})
     end
 
     test "will not pattern match on nil or empty string" do

--- a/test/live_view_native_stylesheet_test.exs
+++ b/test/live_view_native_stylesheet_test.exs
@@ -62,6 +62,12 @@ defmodule LiveViewNative.StylesheetTest do
       assert output == {:ok, ~s({"color-number-3":["rule-1","rule-23"]})}
     end
 
+    test "can convert the output to a string (raising version)" do
+      output = MockSheet.compile_string!(["color-number-3"])
+
+      assert output == ~s({"color-number-3":["rule-1","rule-23"]})
+    end
+
     test "will not pattern match on nil or empty string" do
       output = MockSheet.compile_ast(["color-number-"])
 


### PR DESCRIPTION
Address #86.

> [!WARNING]  
> I'm using `Jason` instead of `:json` for encoding to get past CI. The `:json` implementation is in the first commit, let me know if you want to upgrade the CI and force users to upgrade to OTP 27 and I can rollback to that version.