### PR TITLE
Enhance stylesheet recompilation strategy

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir
-      uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: '1.17' # [Required] Define the Elixir version
         otp-version: '27.1.2'      # [Required] Define the Erlang/OTP version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Emit stylesheets as json instead of Elixir maps
-* pretty printing is not availabile for the time being
-* Elixir 1.17 with OTP 27 is the minimum requirement
+- Emit stylesheets as json instead of Elixir maps
+- pretty printing is not availabile for the time being
+- Elixir 1.17 with OTP 27 is the minimum requirement
+- Ensure stylesheet recompiles if LiveViewNative, LiveViewNativeStylesheet or the format's client version changes
 
 ### Fixed
 
@@ -23,21 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* fix live reload pattern for the sheet file https://github.com/liveview-native/live_view_native_stylesheet/pull/83
+- fix live reload pattern for the sheet file https://github.com/liveview-native/live_view_native_stylesheet/pull/83
 
 ## [0.3.0] 2024-08-21
 
 ### Added
 
-* capture and log raises within `class/1` call when compiling stylesheet
-* removed `_interface` argument from the `class/2` now it is `class/1`
-* added parsing of `style` attribute from all templates (single template files and withing ~LVN templates) to be passed into the respective format's RulesParser
+- capture and log raises within `class/1` call when compiling stylesheet
+- removed `_interface` argument from the `class/2` now it is `class/1`
+- added parsing of `style` attribute from all templates (single template files and withing ~LVN templates) to be passed into the respective format's RulesParser
 
 ### Changed
 
-* fixed line numbers for `~SHEET`
-* refactor `lvn.stylsheet.setup.config` to use `live_view_native`'s updated codegen api
+- fixed line numbers for `~SHEET`
+- refactor `lvn.stylsheet.setup.config` to use `live_view_native`'s updated codegen api
 
 ### Fixed
 
-* resolved issue where pattern matched class names were matching `nil` and `""`
+- resolved issue where pattern matched class names were matching `nil` and `""`


### PR DESCRIPTION
The stylesheet will be forced to recompile if one of the three versions have changed

* LiveViewNative
* LiveViewNativeStylesheet
* format's client library

This ensures that recompilation will be forced to account for any updates to how the AST is being generated